### PR TITLE
feat: update buyer walkthrough 1.2

### DIFF
--- a/data/walkthroughs/scenarios/buyers/1.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.2/index.ts
@@ -1,4 +1,6 @@
 import { WalkthroughData } from "@/types/walkthrough";
+import { sidebarContent1 } from "./sidebar-content/1";
+import { sidebarContent8 } from "./sidebar-content/8";
 
 export const buyerScenario1_2: WalkthroughData = {
   "title": "Offer above cost and win",
@@ -55,10 +57,14 @@ export const buyerScenario1_2: WalkthroughData = {
       "products": { "biodiversity": 1, "nutrients": 4 }
     }
   ],
+  sidebarContent: {
+    1: sidebarContent1,
+    8: sidebarContent8,
+  },
   "options": {
-    "total_bids": "300,000",
-    "total_offers": "130,000",
-    "surplus": "170,000",
+    "total_bids": "200,000",
+    "total_offers": "180,000",
+    "surplus": "20,000",
     "next_walkthrough": "1.3",
     "next_walkthrough_title": "Offer above cost and lose",
     "stages": 8,

--- a/data/walkthroughs/scenarios/buyers/1.2/sidebar-content/1.tsx
+++ b/data/walkthroughs/scenarios/buyers/1.2/sidebar-content/1.tsx
@@ -1,0 +1,21 @@
+export const sidebarContent1 = (
+  <>
+    <p>
+      Of course, buyers do not have to bid at value.
+    </p>
+    <p>
+      When bidding £120,000 it turned out that you only needed to pay £107,500
+      to secure your desired credit bundle.
+    </p>
+    <p>
+      That suggests that the market might have accepted a lower bid.
+    </p>
+    <p>
+      So, let's see what happens if, instead of bidding at value, you instead
+      enter a below value bid of £100,000.
+    </p>
+    <p className="font-bold">
+      Enter that bid now, submit it and then solve the market.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/buyers/1.2/sidebar-content/8.tsx
+++ b/data/walkthroughs/scenarios/buyers/1.2/sidebar-content/8.tsx
@@ -1,0 +1,20 @@
+export const sidebarContent8 = (
+  <>
+    <p>
+      You are successful again!
+    </p>
+    <p>
+      Since you entered a lower bid, you generate less surplus for the market
+      than when you bid at value.
+    </p>
+    <p>
+      As a consequence, the share of the market surplus you receive as a
+      discount is also smaller; falling from £10,250 to £2500.
+    </p>
+    <p>
+      All the same, bidding lower worked to your overall advantage. Even with
+      the smaller discount, you managed to source your credit bundle for only
+      £97,500.
+    </p>
+  </>
+);


### PR DESCRIPTION
Includes a few tweaks to the final values, from the design:

<img width="998" alt="image" src="https://user-images.githubusercontent.com/5636273/201785334-91124992-463a-452e-a051-5022f8075875.png">

I assume the values we have on the designs are what we want? Or maybe these were intentionally changed for some reason. If so they can change back easily enough, of course.