### PR TITLE
feat: update buyer walkthrough 2.3

### DIFF
--- a/data/walkthroughs/scenarios/buyers/2.3/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.3/index.ts
@@ -1,4 +1,7 @@
 import { WalkthroughData } from "@/types/walkthrough";
+import { sidebarContent1 } from "./sidebar-content/1";
+import { sidebarContent8 } from "./sidebar-content/8";
+import {  sidebarContent9 } from "./sidebar-content/9";
 
 export const buyerScenario2_3: WalkthroughData = {
   "title": "Restricted Surplus",
@@ -39,6 +42,11 @@ export const buyerScenario2_3: WalkthroughData = {
       "products": { "biodiversity": 3, "nutrients": 3 }
     }
   ],
+  sidebarContent: {
+    1: sidebarContent1,
+    8: sidebarContent8,
+    9: sidebarContent9,
+  },
   "options": {
     "total_bids": "280,000",
     "total_offers": "140,000",

--- a/data/walkthroughs/scenarios/buyers/2.3/sidebar-content/1.tsx
+++ b/data/walkthroughs/scenarios/buyers/2.3/sidebar-content/1.tsx
@@ -1,0 +1,12 @@
+export const sidebarContent1 = (
+  <>
+    <p>
+      Finally, let's consider the opposite extreme where you are the only buyer
+      in the market. This time we have 3 sellers competing with each other to
+      meet your demand for credits.
+    </p>
+    <p>
+      Once again, submit a bid at value for £280,000 and then solve the market.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/buyers/2.3/sidebar-content/8.tsx
+++ b/data/walkthroughs/scenarios/buyers/2.3/sidebar-content/8.tsx
@@ -1,0 +1,21 @@
+export const sidebarContent8 = (
+  <>
+    <p>
+      Not surprisingly, you are successful. The market again generates a surplus
+      of £140,000, but this time you are rewarded with the lion's share of that
+      surplus as a discount of £130,000.
+    </p>
+    <p>
+      You only pay £150,000 for your credit bundle.
+    </p>
+    <p>
+      Your share of the surplus is high because, unlike in the previous market,
+      your demand was critical to the creation of market surplus.
+    </p>
+    <p>
+      The key lesson here is that how well a buyer fare's in the market not only
+      depends on how they bid but also on the level of competition that they
+      face in sourcing credits.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/buyers/2.3/sidebar-content/9.tsx
+++ b/data/walkthroughs/scenarios/buyers/2.3/sidebar-content/9.tsx
@@ -1,0 +1,7 @@
+export const sidebarContent9 = (
+  <p>
+    The key lesson of this walkthrough is that how well a buyer fare's in the
+    market not only depends on how they bid but also on the level of competition
+    that they face in sourcing credits.
+  </p>
+);


### PR DESCRIPTION
I notice that the final screen for this scenario contains a "return to index" link, which I think is the first one I have noticed so there is a bit of inconsistency there.

<img width="883" alt="image" src="https://user-images.githubusercontent.com/5636273/201791951-e9bc8edc-8663-4a1c-a1dd-25a6cb8fb052.png">

A little randomly some other walkthroughs have this sort of return button on the sidebar:

<img width="646" alt="image" src="https://user-images.githubusercontent.com/5636273/201879139-d5bf255b-9327-4073-b06a-ee4f85ffbc5c.png">

Probably we want to choose one of those and apply it consistently!