### PR TITLE
Various tweaks

### DIFF
--- a/components/walkthroughs/Main/Buyer.tsx
+++ b/components/walkthroughs/Main/Buyer.tsx
@@ -7,20 +7,28 @@ import { fadeInDown } from "@/utils/animations";
 
 import HammerIcon from "../icons/HammerIcon";
 import PoundcashTag from "../icons/PoundcashTag";
+import { RoleId } from "@/types/roles";
 
 type Props = {
   buyer: BuyerType;
   stage: number;
   options: WalkthroughOptions;
+  roleId: RoleId;
   className?: string;
 };
 
-const Buyer = ({ buyer, stage, options, className = "" }: Props) => {
+const Buyer = ({
+  buyer,
+  stage,
+  options,
+  className = "",
+  roleId,
+}: Props) => {
   const { bid, discount, pays, products, title, id } = buyer;
-  const { show_bids, show_surpluses, show_final_payments, highlight_me, role } =
+  const { show_bids, show_surpluses, show_final_payments, highlight_me } =
     options;
 
-  const highlightMe = role === "buyer" && stage >= highlight_me && id === 1;
+  const highlightMe = roleId === "buyer" && stage >= highlight_me && id === 1;
 
   return (
     <motion.div

--- a/components/walkthroughs/Main/MainContent.tsx
+++ b/components/walkthroughs/Main/MainContent.tsx
@@ -8,18 +8,21 @@ import { Buyer, WalkthroughData, Seller } from "@/types/walkthrough";
 import MarketOutcome from "./MarketOutcome";
 import LoadingOverlay from "./LoadingOverlay";
 import ParticipantsList from "./ParticipantsList";
+import { RoleId } from "@/types/roles";
 
 type Props = {
   stage: number;
   setStage: Dispatch<SetStateAction<number>>;
   data: WalkthroughData;
+  roleId: RoleId;
 };
 
-const filterUser = <
-  T extends (Seller | Buyer
-)[]>(arr: T) => arr.filter((item) => item.id !== 1)
-
-const MainContent = ({ stage, setStage, data }: Props) => {
+const MainContent = ({
+  stage,
+  setStage,
+  data,
+  roleId,
+}: Props) => {
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout>;
 
@@ -38,12 +41,6 @@ const MainContent = ({ stage, setStage, data }: Props) => {
       clearTimeout(timer);
     };
   }, [stage, data.options]);
-
-  // Last stage of each walkthrough
-  const maxStage = data.options.stages;
-
-  // User role either buyer or seller
-  const role = data.options.role;
 
   // Lists excluding user
   const sellersExcludingUser = data.sellers.filter((seller) => seller.id !== 1);
@@ -77,6 +74,7 @@ const MainContent = ({ stage, setStage, data }: Props) => {
                 type="losers"
                 stage={stage}
                 data={data}
+                roleId={roleId}
               />
             </motion.div>
           )}
@@ -90,21 +88,23 @@ const MainContent = ({ stage, setStage, data }: Props) => {
                 animate="visible"
                 className="space-y-5"
               >
-                {role === "seller" && (
+                {roleId === "seller" && (
                   <ParticipantsList
                     sellers={sellersExcludingUser}
                     buyers={data.buyers}
                     stage={stage}
                     data={data}
+                    roleId={roleId}
                   />
                 )}
 
-                {role === "buyer" && (
+                {roleId === "buyer" && (
                   <ParticipantsList
                     sellers={data.sellers}
                     buyers={buyersExcludingUser}
                     stage={stage}
                     data={data}
+                    roleId={roleId}
                   />
                 )}
               </motion.div>
@@ -124,6 +124,7 @@ const MainContent = ({ stage, setStage, data }: Props) => {
                     buyers={data.buyers}
                     stage={stage}
                     data={data}
+                    roleId={roleId}
                   />
                 </motion.div>
               )}
@@ -141,6 +142,7 @@ const MainContent = ({ stage, setStage, data }: Props) => {
                   buyers={buyersWon}
                   stage={stage}
                   data={data}
+                  roleId={roleId}
                 />
               </motion.div>
             )}

--- a/components/walkthroughs/Main/ParticipantsList.tsx
+++ b/components/walkthroughs/Main/ParticipantsList.tsx
@@ -4,6 +4,7 @@ import BuyerLost from "./BuyerLost";
 import SellerLost from "./SellerLost";
 
 import { WalkthroughData, Seller as SellerType, Buyer as BuyerType } from "@/types/walkthrough";
+import { RoleId } from "@/types/roles";
 
 type Props = {
   buyers: BuyerType[];
@@ -11,6 +12,7 @@ type Props = {
   stage: number;
   data: WalkthroughData;
   type?: "winners" | "losers";
+  roleId: RoleId;
 };
 
 const ParticipantsList = ({
@@ -18,6 +20,7 @@ const ParticipantsList = ({
   sellers,
   stage,
   data,
+  roleId,
   type = "winners",
 }: Props) => {
   return (
@@ -32,6 +35,7 @@ const ParticipantsList = ({
                 stage={stage}
                 seller={seller}
                 options={data.options}
+                roleId={roleId}
               />
             ))}
           </div>
@@ -44,6 +48,7 @@ const ParticipantsList = ({
                 stage={stage}
                 buyer={buyer}
                 options={data.options}
+                roleId={roleId}
               />
             ))}
           </div>

--- a/components/walkthroughs/Main/Seller.tsx
+++ b/components/walkthroughs/Main/Seller.tsx
@@ -7,25 +7,26 @@ import { fadeInDown } from "@/utils/animations";
 
 import HammerIcon from "../icons/HammerIcon";
 import CartPlus from "../icons/CartPlus";
+import { RoleId } from "@/types/roles";
 
 type Props = {
   seller: SellerType;
   stage: number;
   options: WalkthroughOptions;
   className?: string;
+  roleId: RoleId;
 };
 
-const Seller = ({ seller, stage, options, className = "" }: Props) => {
+const Seller = ({ seller, stage, options, className = "", roleId }: Props) => {
   const { offer, bonus, received, products, title, id } = seller;
   const {
     show_offers,
     show_surpluses,
     show_final_payments,
     highlight_me,
-    role,
   } = options;
 
-  const highlightMe = role === "seller" && stage >= highlight_me && id === 1;
+  const highlightMe = roleId === "seller" && stage >= highlight_me && id === 1;
 
   return (
     <motion.div

--- a/components/walkthroughs/sidebar/Description.tsx
+++ b/components/walkthroughs/sidebar/Description.tsx
@@ -4,16 +4,10 @@ import { fadeIn } from "@/utils/animations";
 import { ReactNode } from "react";
 
 type Props = {
-  // walkthrough: number;
-  stage: number;
-  // nextWalkthrough: () => void;
   children: ReactNode;
 };
 
 const Navigation = ({
-  // walkthrough,
-  stage,
-  // nextWalkthrough,
   children,
 }: Props) => {
   const hide = !children;

--- a/components/walkthroughs/sidebar/Details.tsx
+++ b/components/walkthroughs/sidebar/Details.tsx
@@ -8,25 +8,25 @@ import SellerVector from "@/components/walkthroughs/icons/SellerVector";
 import BuyerVector from "@/components/walkthroughs/icons/BuyerVector";
 import BiodiversityIconGray from "@/components/walkthroughs/icons/BiodiversityIcon";
 import NutrientsIcon from "@/components/walkthroughs/icons/NutrientsIcon";
+import { RoleId } from "@/types/roles";
+import { roles } from "data/roles";
 
 type Props = {
   next: () => void;
   stage: number;
   data: WalkthroughData;
+  roleId: RoleId;
 };
 
-const Details = ({ data, stage, next }: Props) => {
+const Details = ({ data, stage, next, roleId }: Props) => {
   const [price, setPrice] = useState("");
-
-  // User role either buyer or seller
-  const role = data.options.role;
 
   // Project cost
   const projectCost = data.project_cost;
 
   // User input price
   const myPrice: string =
-    role === "seller"
+    roleId === "seller"
       ? data.sellers.find((seller) => seller.id === 1)?.offer!
       : data.buyers.find((buyer) => buyer.id === 1)?.bid!;
 
@@ -54,12 +54,12 @@ const Details = ({ data, stage, next }: Props) => {
     >
       <div className="text-black text-xl">
         <p className="font-bold">My Project</p>
-        <p>{role === "seller" ? "Landholder" : "Developer"}</p>
+        <p>{roles[roleId]}</p>
       </div>
 
       <div className="mt-3 flex justify-between">
         {/* Vector */}
-        <>{role === "seller" ? <SellerVector /> : <BuyerVector />}</>
+        <>{roleId === "seller" ? <SellerVector /> : <BuyerVector />}</>
 
         {/* Credits */}
         <div className="flex gap-x-2 mt-2">

--- a/components/walkthroughs/sidebar/Details.tsx
+++ b/components/walkthroughs/sidebar/Details.tsx
@@ -54,7 +54,7 @@ const Details = ({ data, stage, next, roleId }: Props) => {
     >
       <div className="text-black text-xl">
         <p className="font-bold">My Project</p>
-        <p>{roles[roleId]}</p>
+        <p>{roles[roleId].label}</p>
       </div>
 
       <div className="mt-3 flex justify-between">

--- a/components/walkthroughs/sidebar/Navigation.tsx
+++ b/components/walkthroughs/sidebar/Navigation.tsx
@@ -25,7 +25,7 @@ const Navigation = ({
   return (
     <motion.div layout className="text-center text-xl w-full">
       <p className="text-green-dark">WALKTHROUGH {scenarioId}</p>
-      <div className="flex gap-x-4 items-center">
+      <div className="flex gap-x-4 items-center justify-between">
         {/* Previous button */}
         <PrevButton
           onClick={previous}
@@ -33,7 +33,9 @@ const Navigation = ({
           hideButton={data.options.hide_prev_button}
         />
 
-        <div className="bg-green-dark text-white rounded-lg px-3 py-1 max-w-[285px]">
+        <div
+          className="bg-green-dark text-white rounded-lg px-3 py-1 flex-1"
+        >
           <p>{title}</p>
         </div>
 

--- a/components/walkthroughs/sidebar/Navigation.tsx
+++ b/components/walkthroughs/sidebar/Navigation.tsx
@@ -6,6 +6,7 @@ import NextButton from "./NextButton";
 import PrevButton from "./PrevButton";
 
 type Props = {
+  title: string;
   scenarioId: string;
   stage: number;
   next: () => void;
@@ -13,7 +14,14 @@ type Props = {
   data: WalkthroughData;
 };
 
-const Navigation = ({ scenarioId, stage, next, previous, data }: Props) => {
+const Navigation = ({
+  title,
+  scenarioId,
+  stage,
+  next,
+  previous,
+  data,
+}: Props) => {
   return (
     <motion.div layout className="text-center text-xl w-full">
       <p className="text-green-dark">WALKTHROUGH {scenarioId}</p>
@@ -26,7 +34,7 @@ const Navigation = ({ scenarioId, stage, next, previous, data }: Props) => {
         />
 
         <div className="bg-green-dark text-white rounded-lg px-3 py-1 max-w-[285px]">
-          <p>Bidding Strategies for a Package Buyer</p>
+          <p>{title}</p>
         </div>
 
         {/* Next button */}

--- a/components/walkthroughs/sidebar/SideBar.tsx
+++ b/components/walkthroughs/sidebar/SideBar.tsx
@@ -61,7 +61,12 @@ const SideBar = ({
       <AnimatePresence>
         {/* Top */}
         {stage >= data.options.show_details_widget && (
-          <Details next={next} data={data} stage={stage} />
+          <Details
+            next={next}
+            data={data}
+            stage={stage}
+            roleId={roleId}
+          />
         )}
 
         {/* Solve Market Button */}

--- a/components/walkthroughs/sidebar/SideBar.tsx
+++ b/components/walkthroughs/sidebar/SideBar.tsx
@@ -44,13 +44,12 @@ const SideBar = ({
       <AnimatePresence>
         {/* Top */}
         {stage >= data.options.show_details_widget && (
-          <Details key={1} next={next} data={data} stage={stage} />
+          <Details next={next} data={data} stage={stage} />
         )}
 
         {/* Solve Market Button */}
         {stage === showSolveMarketBtn && (
           <motion.button
-            key={2}
             variants={fadeIn}
             initial="hidden"
             animate="visible"
@@ -66,7 +65,6 @@ const SideBar = ({
 
         {/* Navigation with next and previous buttons */}
         <Navigation
-          key={3}
           scenarioId={scenarioId}
           stage={stage}
           next={next}
@@ -75,10 +73,7 @@ const SideBar = ({
         />
 
         {/* Walkthrough Description text */}
-        <Description
-          key={4}
-          stage={stage}
-        >
+        <Description>
           {sidebarContent}
         </Description>
       </AnimatePresence>

--- a/components/walkthroughs/sidebar/SideBar.tsx
+++ b/components/walkthroughs/sidebar/SideBar.tsx
@@ -7,10 +7,14 @@ import { WalkthroughData } from "@/types/walkthrough";
 import Description from "./Description";
 import Details from "./Details";
 import Navigation from "./Navigation";
+import { getNextScenario } from "@/utils/walkthroughs";
+import { useRouter } from "next/router";
+import { RoleId } from "@/types/roles";
 
 type Props = {
   title: string;
   scenarioId: string;
+  roleId: RoleId;
   stage: number;
   setStage: Dispatch<SetStateAction<number>>;
   data: WalkthroughData;
@@ -20,6 +24,7 @@ type Props = {
 const SideBar = ({
   title,
   scenarioId,
+  roleId,
   stage,
   setStage,
   data,
@@ -27,13 +32,23 @@ const SideBar = ({
 }: Props) => {
   const maxStage = data.options.stages;
   const showSolveMarketBtn = data.options.show_solve_market;
+  const nextScenario = getNextScenario(scenarioId, roleId);
+  const router = useRouter();
 
   const previous = () => {
     if (stage > 1) setStage((prev) => prev - 1);
   };
 
   const next = () => {
-    if (maxStage && stage < maxStage) setStage((prev) => prev + 1);
+    if (maxStage && stage < maxStage) {
+      setStage((prev) => prev + 1);
+
+      return;
+    }
+
+    if (nextScenario) {
+      router.push(`/how-it-works/${nextScenario.id}/${roleId}`);
+    }
   };
 
   const onButtonClick = (e: React.FormEvent) => {

--- a/components/walkthroughs/sidebar/SideBar.tsx
+++ b/components/walkthroughs/sidebar/SideBar.tsx
@@ -34,10 +34,6 @@ const SideBar = ({
     if (maxStage && stage < maxStage) setStage((prev) => prev + 1);
   };
 
-  // const nextWalkthrough = () => {
-  //   setWalkthrough(data.options.next_walkthrough);
-  // };
-
   const onButtonClick = (e: React.FormEvent) => {
     e.preventDefault();
     next();
@@ -81,9 +77,7 @@ const SideBar = ({
         {/* Walkthrough Description text */}
         <Description
           key={4}
-          // walkthrough={walkthrough}
           stage={stage}
-          // nextWalkthrough={nextWalkthrough}
         >
           {sidebarContent}
         </Description>

--- a/components/walkthroughs/sidebar/SideBar.tsx
+++ b/components/walkthroughs/sidebar/SideBar.tsx
@@ -9,6 +9,7 @@ import Details from "./Details";
 import Navigation from "./Navigation";
 
 type Props = {
+  title: string;
   scenarioId: string;
   stage: number;
   setStage: Dispatch<SetStateAction<number>>;
@@ -17,6 +18,7 @@ type Props = {
 };
 
 const SideBar = ({
+  title,
   scenarioId,
   stage,
   setStage,
@@ -65,6 +67,7 @@ const SideBar = ({
 
         {/* Navigation with next and previous buttons */}
         <Navigation
+          title={title}
           scenarioId={scenarioId}
           stage={stage}
           next={next}

--- a/data/roles.ts
+++ b/data/roles.ts
@@ -7,4 +7,7 @@ export const roles: Roles = {
   seller: {
     label: 'Landholder',
   },
+  generic: {
+    label: 'None',
+  },
 };

--- a/data/walkthroughs/index.ts
+++ b/data/walkthroughs/index.ts
@@ -64,7 +64,7 @@ export const walkthroughs: Walkthrough[] = [
     scenarios: [
       {
         id: '2.1',
-        title: 'Baland supply & demand',
+        title: 'Balanced supply & demand',
         roles: {
           buyer: buyerScenario2_1,
           seller: sellerScenario2_1,

--- a/data/walkthroughs/index.ts
+++ b/data/walkthroughs/index.ts
@@ -18,26 +18,43 @@ import { sellerScenario3_2 } from "./scenarios/sellers/3.2";
 
 export const walkthroughs: Walkthrough[] = [
   {
+    id: 0,
+    title: 'Market Introduction',
+    scenarios: [
+      {
+        id: '0.0',
+        title: 'Market Introduction',
+        roles: {},
+      },
+    ]
+  },
+  {
     id: 1,
     title: 'Bidding High & Low',
     scenarios: [
       {
         id: '1.1',
         title: 'Offer at cost and win',
-        buyer: buyerScenario1_1,
-        seller: sellerScenario1_1,
+        roles: {
+          buyer: buyerScenario1_1,
+          seller: sellerScenario1_1,
+        },
       },
       {
         id: '1.2',
         title: 'Offer above cost and win',
-        buyer: buyerScenario1_2,
-        seller: sellerScenario1_2,
+        roles: {
+          buyer: buyerScenario1_2,
+          seller: sellerScenario1_2,
+        },
       },
       {
         id: '1.3',
         title: 'Offer above cost and lose',
-        buyer: buyerScenario1_3,
-        seller: sellerScenario1_3,
+        roles: {
+          buyer: buyerScenario1_3,
+          seller: sellerScenario1_3,
+        },
       },
     ]
   },
@@ -48,20 +65,26 @@ export const walkthroughs: Walkthrough[] = [
       {
         id: '2.1',
         title: 'Baland supply & demand',
-        buyer: buyerScenario2_1,
-        seller: sellerScenario2_1,
+        roles: {
+          buyer: buyerScenario2_1,
+          seller: sellerScenario2_1,
+        },
       },
       {
         id: '2.2',
         title: 'Resitricted supply',
-        buyer: buyerScenario2_2,
-        seller: sellerScenario2_2,
+        roles: {
+          buyer: buyerScenario2_2,
+          seller: sellerScenario2_2,
+        },
       },
       {
         id: '2.3',
         title: 'Resitricted Demand',
-        buyer: buyerScenario2_3,
-        seller: sellerScenario2_3,
+        roles: {
+          buyer: buyerScenario2_3,
+          seller: sellerScenario2_3,
+        },
       },
     ]
   },
@@ -72,14 +95,18 @@ export const walkthroughs: Walkthrough[] = [
       {
         id: '3.1',
         title: 'Poor fit bid',
-        buyer: buyerScenario3_1,
-        seller: sellerScenario3_1,
+        roles: {
+          buyer: buyerScenario3_1,
+          seller: sellerScenario3_1,
+        },
       },
       {
         id: '3.2',
         title: 'Good fit bid',
-        buyer: buyerScenario3_2,
-        seller: sellerScenario3_2,
+        roles: {
+          buyer: buyerScenario3_2,
+          seller: sellerScenario3_2,
+        },
       },
     ]
   },

--- a/data/walkthroughs/scenarios/buyers/1.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.1/index.ts
@@ -75,8 +75,6 @@ export const buyerScenario1_1: WalkthroughData = {
     "total_bids": "220,000",
     "total_offers": "180,000",
     "surplus": "40,000",
-    "next_walkthrough": "1.2",
-    "next_walkthrough_title": "Offer above cost and win",
     "stages": 12,
     "role": "buyer",
     "set_my_price": 5,

--- a/data/walkthroughs/scenarios/buyers/1.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.1/index.ts
@@ -94,7 +94,7 @@ export const buyerScenario1_1: WalkthroughData = {
     "show_full_map": 1,
     "show_highlighted_map": 2,
     "show_participants": 3,
-    "hide_next_button": [5, 6, 7, 8, 9, 10, 11, 12],
+    "hide_next_button": [5, 6, 7, 8, 9, 10, 11],
     "hide_prev_button": [1],
     "show_losers": 8,
     "highlight_me": 6

--- a/data/walkthroughs/scenarios/buyers/1.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.1/index.ts
@@ -8,7 +8,6 @@ import { sidebarContent5 } from "./sidebar-content/5";
 import { sidebarContent6 } from "./sidebar-content/6";
 
 export const buyerScenario1_1: WalkthroughData = {
-  "title": "Offer at cost and win",
   "project_cost": "120,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/buyers/1.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.1/index.ts
@@ -75,7 +75,6 @@ export const buyerScenario1_1: WalkthroughData = {
     "total_offers": "180,000",
     "surplus": "40,000",
     "stages": 12,
-    "role": "buyer",
     "set_my_price": 5,
     "allow_button_click": 5,
     "show_calculating_overlay": [7, 9, 11],

--- a/data/walkthroughs/scenarios/buyers/1.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.2/index.ts
@@ -84,7 +84,7 @@ export const buyerScenario1_2: WalkthroughData = {
     "show_full_map": 1,
     "show_highlighted_map": 2,
     "show_participants": 1,
-    "hide_next_button": [1, 2, 3, 4, 5, 6, 7, 8],
+    "hide_next_button": [1, 2, 3, 4, 5, 6, 7],
     "hide_prev_button": [1],
     "show_losers": 4,
     "highlight_me": 2

--- a/data/walkthroughs/scenarios/buyers/1.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.2/index.ts
@@ -65,7 +65,6 @@ export const buyerScenario1_2: WalkthroughData = {
     "total_offers": "180,000",
     "surplus": "20,000",
     "stages": 8,
-    "role": "buyer",
     "set_my_price": 1,
     "allow_button_click": 1,
     "show_calculating_overlay": [3, 5, 7],

--- a/data/walkthroughs/scenarios/buyers/1.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.2/index.ts
@@ -3,7 +3,6 @@ import { sidebarContent1 } from "./sidebar-content/1";
 import { sidebarContent8 } from "./sidebar-content/8";
 
 export const buyerScenario1_2: WalkthroughData = {
-  "title": "Offer above cost and win",
   "project_cost": "120,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/buyers/1.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.2/index.ts
@@ -65,8 +65,6 @@ export const buyerScenario1_2: WalkthroughData = {
     "total_bids": "200,000",
     "total_offers": "180,000",
     "surplus": "20,000",
-    "next_walkthrough": "1.3",
-    "next_walkthrough_title": "Offer above cost and lose",
     "stages": 8,
     "role": "buyer",
     "set_my_price": 1,

--- a/data/walkthroughs/scenarios/buyers/1.3/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.3/index.ts
@@ -3,7 +3,6 @@ import { sidebarContent1 } from "./sidebar-content/1";
 import { sidebarContent8 } from "./sidebar-content/8";
 
 export const buyerScenario1_3: WalkthroughData = {
-  "title": "Offer above cost and lose",
   "project_cost": "120,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/buyers/1.3/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.3/index.ts
@@ -65,8 +65,6 @@ export const buyerScenario1_3: WalkthroughData = {
     "total_bids": "210,000",
     "total_offers": "200,000",
     "surplus": "10,000",
-    "next_walkthrough": "2.1",
-    "next_walkthrough_title": "Balanced Supply & Demand",
     "stages": 8,
     "role": "buyer",
     "set_my_price": 1,

--- a/data/walkthroughs/scenarios/buyers/1.3/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.3/index.ts
@@ -65,7 +65,6 @@ export const buyerScenario1_3: WalkthroughData = {
     "total_offers": "200,000",
     "surplus": "10,000",
     "stages": 8,
-    "role": "buyer",
     "set_my_price": 1,
     "allow_button_click": 1,
     "show_calculating_overlay": [3, 5, 7],

--- a/data/walkthroughs/scenarios/buyers/2.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.1/index.ts
@@ -89,7 +89,7 @@ export const buyerScenario2_1: WalkthroughData = {
     "show_full_map": 1,
     "show_highlighted_map": 2,
     "show_participants": 3,
-    "hide_next_button": [3, 4, 5, 6, 7, 8, 9, 10],
+    "hide_next_button": [3, 4, 5, 6, 7, 8, 9],
     "hide_prev_button": [1],
     "show_losers": 6,
     "highlight_me": 4

--- a/data/walkthroughs/scenarios/buyers/2.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.1/index.ts
@@ -5,7 +5,6 @@ import { sidebarContent2 } from "./sidebar-content/2";
 import { sidebarContent3 } from "./sidebar-content/3";
 
 export const buyerScenario2_1: WalkthroughData = {
-  "title": "Balanced Supply & Demand",
   "project_cost": "280,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/buyers/2.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.1/index.ts
@@ -69,8 +69,6 @@ export const buyerScenario2_1: WalkthroughData = {
     "total_bids": "780,000",
     "total_offers": "420,000",
     "surplus": "360,000",
-    "next_walkthrough": "2.2",
-    "next_walkthrough_title": "Restricted Supply",
     "stages": 10,
     "role": "buyer",
     "set_my_price": 3,

--- a/data/walkthroughs/scenarios/buyers/2.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.1/index.ts
@@ -69,7 +69,6 @@ export const buyerScenario2_1: WalkthroughData = {
     "total_offers": "420,000",
     "surplus": "360,000",
     "stages": 10,
-    "role": "buyer",
     "set_my_price": 3,
     "allow_button_click": 3,
     "show_calculating_overlay": [5, 7, 9],

--- a/data/walkthroughs/scenarios/buyers/2.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.2/index.ts
@@ -49,8 +49,6 @@ export const buyerScenario2_2: WalkthroughData = {
     "total_bids": "280,000",
     "total_offers": "140,000",
     "surplus": "140,000",
-    "next_walkthrough": "2.3",
-    "next_walkthrough_title": "Restricted Surplus",
     "stages": 8,
     "role": "buyer",
     "set_my_price": 1,

--- a/data/walkthroughs/scenarios/buyers/2.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.2/index.ts
@@ -3,7 +3,6 @@ import { sidebarContent1 } from "./sidebar-content/1";
 import { sidebarContent8 } from "./sidebar-content/8";
 
 export const buyerScenario2_2: WalkthroughData = {
-  "title": "Restricted Supply",
   "project_cost": "280,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/buyers/2.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.2/index.ts
@@ -68,7 +68,7 @@ export const buyerScenario2_2: WalkthroughData = {
     "show_full_map": 1,
     "show_highlighted_map": 2,
     "show_participants": 1,
-    "hide_next_button": [1, 3, 4, 5, 6, 7, 8],
+    "hide_next_button": [1, 3, 4, 5, 6, 7],
     "hide_prev_button": [1],
     "show_losers": 4,
     "highlight_me": 2

--- a/data/walkthroughs/scenarios/buyers/2.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.2/index.ts
@@ -49,7 +49,6 @@ export const buyerScenario2_2: WalkthroughData = {
     "total_offers": "140,000",
     "surplus": "140,000",
     "stages": 8,
-    "role": "buyer",
     "set_my_price": 1,
     "allow_button_click": 1,
     "show_calculating_overlay": [3, 5, 7],

--- a/data/walkthroughs/scenarios/buyers/2.3/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.3/index.ts
@@ -51,7 +51,6 @@ export const buyerScenario2_3: WalkthroughData = {
     "total_offers": "140,000",
     "surplus": "140,000",
     "stages": 9,
-    "role": "buyer",
     "set_my_price": 1,
     "allow_button_click": 1,
     "show_calculating_overlay": [3, 5, 7],

--- a/data/walkthroughs/scenarios/buyers/2.3/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.3/index.ts
@@ -4,7 +4,6 @@ import { sidebarContent8 } from "./sidebar-content/8";
 import {  sidebarContent9 } from "./sidebar-content/9";
 
 export const buyerScenario2_3: WalkthroughData = {
-  "title": "Restricted Surplus",
   "project_cost": "280,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/buyers/2.3/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.3/index.ts
@@ -51,8 +51,6 @@ export const buyerScenario2_3: WalkthroughData = {
     "total_bids": "280,000",
     "total_offers": "140,000",
     "surplus": "140,000",
-    "next_walkthrough": "3.1",
-    "next_walkthrough_title": "Poor fit bid",
     "stages": 9,
     "role": "buyer",
     "set_my_price": 1,

--- a/data/walkthroughs/scenarios/buyers/3.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/3.1/index.ts
@@ -59,7 +59,6 @@ export const buyerScenario3_1: WalkthroughData = {
     "total_offers": "150,000",
     "surplus": "150,000",
     "stages": 10,
-    "role": "buyer",
     "set_my_price": 3,
     "allow_button_click": 3,
     "show_calculating_overlay": [5, 7, 9],

--- a/data/walkthroughs/scenarios/buyers/3.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/3.1/index.ts
@@ -1,7 +1,6 @@
 import { WalkthroughData } from "@/types/walkthrough";
 
 export const buyerScenario3_1: WalkthroughData = {
-  "title": "Poor fit bid",
   "project_cost": "60,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/buyers/3.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/3.1/index.ts
@@ -59,8 +59,6 @@ export const buyerScenario3_1: WalkthroughData = {
     "total_bids": "300,000",
     "total_offers": "150,000",
     "surplus": "150,000",
-    "next_walkthrough": "3.2",
-    "next_walkthrough_title": "Poor fit bid",
     "stages": 10,
     "role": "buyer",
     "set_my_price": 3,

--- a/data/walkthroughs/scenarios/buyers/3.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/3.1/index.ts
@@ -78,7 +78,7 @@ export const buyerScenario3_1: WalkthroughData = {
     "show_full_map": 1,
     "show_highlighted_map": 2,
     "show_participants": 3,
-    "hide_next_button": [3, 4, 5, 6, 7, 8, 9, 10],
+    "hide_next_button": [3, 4, 5, 6, 7, 8, 9],
     "hide_prev_button": [1],
     "show_losers": 6,
     "highlight_me": 4

--- a/data/walkthroughs/scenarios/buyers/3.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/3.2/index.ts
@@ -59,7 +59,6 @@ export const buyerScenario3_2: WalkthroughData = {
     "total_offers": "360,000",
     "surplus": "200,000",
     "stages": 9,
-    "role": "buyer",
     "set_my_price": 1,
     "allow_button_click": 1,
     "show_calculating_overlay": [3, 5, 7],

--- a/data/walkthroughs/scenarios/buyers/3.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/3.2/index.ts
@@ -59,8 +59,6 @@ export const buyerScenario3_2: WalkthroughData = {
     "total_bids": "560,000",
     "total_offers": "360,000",
     "surplus": "200,000",
-    "next_walkthrough": "4",
-    "next_walkthrough_title": "Poor fit bid",
     "stages": 9,
     "role": "buyer",
     "set_my_price": 1,

--- a/data/walkthroughs/scenarios/buyers/3.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/3.2/index.ts
@@ -1,7 +1,6 @@
 import { WalkthroughData } from "@/types/walkthrough";
 
 export const buyerScenario3_2: WalkthroughData = {
-  "title": "Poor fit bid",
   "project_cost": "60,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/sellers/1.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.1/index.ts
@@ -93,7 +93,7 @@ export const sellerScenario1_1: WalkthroughData = {
     "show_full_map": 1,
     "show_highlighted_map": 2,
     "show_participants": 3,
-    "hide_next_button": [4, 5, 6, 8, 10, 11],
+    "hide_next_button": [4, 5, 6, 8, 10],
     "hide_prev_button": [1],
     "show_losers": 7,
     "highlight_me": 5

--- a/data/walkthroughs/scenarios/sellers/1.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.1/index.ts
@@ -7,7 +7,6 @@ import { sidebarContentStage11 } from "./sidebar-content/11";
 import { WalkthroughData } from "@/types/walkthrough";
 
 export const sellerScenario1_1: WalkthroughData = {
-  "title": "Offer at cost and win",
   "project_cost": "60,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/sellers/1.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.1/index.ts
@@ -73,8 +73,6 @@ export const sellerScenario1_1: WalkthroughData = {
     "total_bids": "300,000",
     "total_offers": "110,000",
     "surplus": "190,000",
-    "next_walkthrough": "1.2",
-    "next_walkthrough_title": "Offer above cost and win",
     "stages": 11,
     "role": "seller",
     "set_my_price": 4,

--- a/data/walkthroughs/scenarios/sellers/1.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.1/index.ts
@@ -73,7 +73,6 @@ export const sellerScenario1_1: WalkthroughData = {
     "total_offers": "110,000",
     "surplus": "190,000",
     "stages": 11,
-    "role": "seller",
     "set_my_price": 4,
     "allow_button_click": 4,
     "show_calculating_overlay": [6, 8, 10],

--- a/data/walkthroughs/scenarios/sellers/1.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.2/index.ts
@@ -3,7 +3,6 @@ import { sidebarContentStage1 } from "./sidebar-content/1";
 import { sidebarContentStage8 } from "./sidebar-content/8";
 
 export const sellerScenario1_2: WalkthroughData = {
-  "title": "Offer above cost and win",
   "project_cost": "60,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/sellers/1.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.2/index.ts
@@ -65,7 +65,6 @@ export const sellerScenario1_2: WalkthroughData = {
     "total_offers": "130,000",
     "surplus": "170,000",
     "stages": 8,
-    "role": "seller",
     "set_my_price": 1,
     "allow_button_click": 1,
     "show_calculating_overlay": [3, 5, 7],

--- a/data/walkthroughs/scenarios/sellers/1.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.2/index.ts
@@ -85,7 +85,7 @@ export const sellerScenario1_2: WalkthroughData = {
     "show_full_map": 1,
     "show_highlighted_map": 2,
     "show_participants": 1,
-    "hide_next_button": [1, 2, 3, 4, 5, 6, 7, 8],
+    "hide_next_button": [1, 2, 3, 4, 5, 6, 7],
     "hide_prev_button": [1],
     "show_losers": 4,
     "highlight_me": 2

--- a/data/walkthroughs/scenarios/sellers/1.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.2/index.ts
@@ -65,8 +65,6 @@ export const sellerScenario1_2: WalkthroughData = {
     "total_bids": "300,000",
     "total_offers": "130,000",
     "surplus": "170,000",
-    "next_walkthrough": "1.3",
-    "next_walkthrough_title": "Offer above cost and lose",
     "stages": 8,
     "role": "seller",
     "set_my_price": 1,

--- a/data/walkthroughs/scenarios/sellers/1.3/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.3/index.ts
@@ -65,8 +65,6 @@ export const sellerScenario1_3: WalkthroughData = {
     "total_bids": "320,000",
     "total_offers": "170,000",
     "surplus": "150,000",
-    "next_walkthrough": "2.1",
-    "next_walkthrough_title": "Balanced Supply & Demand",
     "stages": 8,
     "role": "seller",
     "set_my_price": 1,

--- a/data/walkthroughs/scenarios/sellers/1.3/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.3/index.ts
@@ -65,7 +65,6 @@ export const sellerScenario1_3: WalkthroughData = {
     "total_offers": "170,000",
     "surplus": "150,000",
     "stages": 8,
-    "role": "seller",
     "set_my_price": 1,
     "allow_button_click": 1,
     "show_calculating_overlay": [3, 5, 7],

--- a/data/walkthroughs/scenarios/sellers/1.3/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.3/index.ts
@@ -3,7 +3,6 @@ import { sidebarContentStage1 } from "./sidebar-content/1";
 import { sidebarContentStage8 } from "./sidebar-content/8";
 
 export const sellerScenario1_3: WalkthroughData = {
-  "title": "Offer above cost and lose",
   "project_cost": "60,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/sellers/2.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.1/index.ts
@@ -88,7 +88,7 @@ export const sellerScenario2_1: WalkthroughData = {
     "show_full_map": 1,
     "show_highlighted_map": 2,
     "show_participants": 3,
-    "hide_next_button": [3, 4, 5, 6, 7, 8, 9, 10],
+    "hide_next_button": [3, 4, 5, 6, 7, 8, 9],
     "hide_prev_button": [1],
     "show_losers": 6,
     "highlight_me": 4

--- a/data/walkthroughs/scenarios/sellers/2.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.1/index.ts
@@ -69,7 +69,6 @@ export const sellerScenario2_1: WalkthroughData = {
     "total_offers": "170,000",
     "surplus": "360,000",
     "stages": 10,
-    "role": "seller",
     "set_my_price": 3,
     "allow_button_click": 3,
     "show_calculating_overlay": [5, 7, 9],

--- a/data/walkthroughs/scenarios/sellers/2.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.1/index.ts
@@ -5,7 +5,6 @@ import { sidebarContentStage10 } from "./sidebar-content/10";
 import { WalkthroughData } from "@/types/walkthrough";
 
 export const sellerScenario2_1: WalkthroughData = {
-  "title": "Balanced Supply & Demand",
   "project_cost": "140,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/sellers/2.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.1/index.ts
@@ -69,8 +69,6 @@ export const sellerScenario2_1: WalkthroughData = {
     "total_bids": "580,000",
     "total_offers": "170,000",
     "surplus": "360,000",
-    "next_walkthrough": "2.2",
-    "next_walkthrough_title": "Restricted Supply",
     "stages": 10,
     "role": "seller",
     "set_my_price": 3,

--- a/data/walkthroughs/scenarios/sellers/2.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.2/index.ts
@@ -49,7 +49,6 @@ export const sellerScenario2_2: WalkthroughData = {
     "total_offers": "140,000",
     "surplus": "140,000",
     "stages": 8,
-    "role": "seller",
     "set_my_price": 1,
     "allow_button_click": 1,
     "show_calculating_overlay": [3, 5, 7],

--- a/data/walkthroughs/scenarios/sellers/2.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.2/index.ts
@@ -3,7 +3,6 @@ import { sidebarContentStage1 } from "./sidebar-content/1";
 import { sidebarContentStage8 } from "./sidebar-content/8";
 
 export const sellerScenario2_2: WalkthroughData = {
-  "title": "Restricted Supply",
   "project_cost": "140,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/sellers/2.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.2/index.ts
@@ -68,7 +68,7 @@ export const sellerScenario2_2: WalkthroughData = {
     "show_full_map": 1,
     "show_highlighted_map": 2,
     "show_participants": 1,
-    "hide_next_button": [1, 2, 3, 4, 5, 6, 7, 8],
+    "hide_next_button": [1, 2, 3, 4, 5, 6, 7],
     "hide_prev_button": [1],
     "show_losers": 4,
     "highlight_me": 2

--- a/data/walkthroughs/scenarios/sellers/2.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.2/index.ts
@@ -49,8 +49,6 @@ export const sellerScenario2_2: WalkthroughData = {
     "total_bids": "280,000",
     "total_offers": "140,000",
     "surplus": "140,000",
-    "next_walkthrough": "2.3",
-    "next_walkthrough_title": "Restricted Surplus",
     "stages": 8,
     "role": "seller",
     "set_my_price": 1,

--- a/data/walkthroughs/scenarios/sellers/2.3/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.3/index.ts
@@ -4,7 +4,6 @@ import { sidebarContentStage8 } from "./sidebar-content/8";
 import { sidebarContentStage9 } from "./sidebar-content/9";
 
 export const sellerScenario2_3: WalkthroughData = {
-  "title": "Restricted Surplus",
   "project_cost": "140,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/sellers/2.3/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.3/index.ts
@@ -51,8 +51,6 @@ export const sellerScenario2_3: WalkthroughData = {
     "total_bids": "280,000",
     "total_offers": "140,000",
     "surplus": "140,000",
-    "next_walkthrough": "3.1",
-    "next_walkthrough_title": "Poor fit bid",
     "stages": 9,
     "role": "seller",
     "set_my_price": 1,

--- a/data/walkthroughs/scenarios/sellers/2.3/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.3/index.ts
@@ -51,7 +51,6 @@ export const sellerScenario2_3: WalkthroughData = {
     "total_offers": "140,000",
     "surplus": "140,000",
     "stages": 9,
-    "role": "seller",
     "set_my_price": 1,
     "allow_button_click": 1,
     "show_calculating_overlay": [3, 5, 7],

--- a/data/walkthroughs/scenarios/sellers/3.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/3.1/index.ts
@@ -5,7 +5,6 @@ import { sidebarContentStage10 } from "./sidebar-content/10";
 import { WalkthroughData } from "@/types/walkthrough";
 
 export const sellerScenario3_1: WalkthroughData = {
-  "title": "Poor fit bid",
   "project_cost": "100,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/sellers/3.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/3.1/index.ts
@@ -88,7 +88,7 @@ export const sellerScenario3_1: WalkthroughData = {
     "show_full_map": 1,
     "show_highlighted_map": 2,
     "show_participants": 3,
-    "hide_next_button": [3, 4, 5, 6, 7, 8, 9, 10],
+    "hide_next_button": [3, 4, 5, 6, 7, 8, 9],
     "hide_prev_button": [1],
     "show_losers": 6,
     "highlight_me": 4

--- a/data/walkthroughs/scenarios/sellers/3.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/3.1/index.ts
@@ -69,7 +69,6 @@ export const sellerScenario3_1: WalkthroughData = {
     "total_offers": "120,000",
     "surplus": "280,000",
     "stages": 10,
-    "role": "seller",
     "set_my_price": 3,
     "allow_button_click": 3,
     "show_calculating_overlay": [5, 7, 9],

--- a/data/walkthroughs/scenarios/sellers/3.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/3.1/index.ts
@@ -69,8 +69,6 @@ export const sellerScenario3_1: WalkthroughData = {
     "total_bids": "400,000",
     "total_offers": "120,000",
     "surplus": "280,000",
-    "next_walkthrough": "3.2",
-    "next_walkthrough_title": "Poor fit bid",
     "stages": 10,
     "role": "seller",
     "set_my_price": 3,

--- a/data/walkthroughs/scenarios/sellers/3.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/3.2/index.ts
@@ -67,7 +67,6 @@ export const sellerScenario3_2: WalkthroughData = {
     "total_offers": "300,000",
     "surplus": "450,000",
     "stages": 9,
-    "role": "seller",
     "set_my_price": 1,
     "allow_button_click": 1,
     "show_calculating_overlay": [3, 5, 7],

--- a/data/walkthroughs/scenarios/sellers/3.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/3.2/index.ts
@@ -4,7 +4,6 @@ import { sidebarContentStage8 } from "./sidebar-content/8";
 import { sidebarContentStage9 } from "./sidebar-content/9";
 
 export const sellerScenario3_2: WalkthroughData = {
-  "title": "Poor fit bid",
   "project_cost": "100,000",
   "buyers": [
     {

--- a/data/walkthroughs/scenarios/sellers/3.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/3.2/index.ts
@@ -67,8 +67,6 @@ export const sellerScenario3_2: WalkthroughData = {
     "total_bids": "750,000",
     "total_offers": "300,000",
     "surplus": "450,000",
-    "next_walkthrough": "4",
-    "next_walkthrough_title": "Poor fit bid",
     "stages": 9,
     "role": "seller",
     "set_my_price": 1,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -63,7 +63,12 @@ function MyApp({ Component, pageProps }: AppProps) {
         }}
       />
       <Nav />
-      <Component {...pageProps} />
+      <Component
+        {...pageProps}
+        // Remount components if the route changes
+        // https://nextjs.org/docs/api-reference/next/router#resetting-state-after-navigation
+        key={router.asPath}
+      />
       <Footer />
     </>
   );

--- a/pages/how-it-works/[scenarioId]/[roleId].tsx
+++ b/pages/how-it-works/[scenarioId]/[roleId].tsx
@@ -57,6 +57,7 @@ const HowItWorksWalthrough: NextPage<HowItWorksWalthroughProps> = ({
           stage={stage}
           setStage={setStage}
           data={scenarioForRole}
+          roleId={roleId}
         />
       </div>
     </main>

--- a/pages/how-it-works/[scenarioId]/[roleId].tsx
+++ b/pages/how-it-works/[scenarioId]/[roleId].tsx
@@ -47,6 +47,7 @@ const HowItWorksWalthrough: NextPage<HowItWorksWalthroughProps> = ({
         <SideBar
           stage={stage}
           scenarioId={scenarioId}
+          roleId={roleId}
           setStage={setStage}
           data={scenarioForRole}
           sidebarContent={sidebarContent}

--- a/pages/how-it-works/[scenarioId]/[roleId].tsx
+++ b/pages/how-it-works/[scenarioId]/[roleId].tsx
@@ -13,6 +13,7 @@ import {
   getAllScenarioIds,
   getScenario,
   getScenarioByRole,
+  getWalkthroughForScenario,
   isValidRoleId,
   isValidScenarioId,
 } from "@/utils/walkthroughs";
@@ -36,6 +37,7 @@ const HowItWorksWalthrough: NextPage<HowItWorksWalthroughProps> = ({
   const scenarioForRole = getScenarioByRole(scenarioId, roleId);
   const [stage, setStage] = useState(1);
   const sidebarContent = scenarioForRole.sidebarContent?.[stage];
+  const { title } = getWalkthroughForScenario(scenarioId);
 
   return (
     <main>
@@ -48,6 +50,7 @@ const HowItWorksWalthrough: NextPage<HowItWorksWalthroughProps> = ({
           setStage={setStage}
           data={scenarioForRole}
           sidebarContent={sidebarContent}
+          title={title}
         />
         <MainContent
           stage={stage}

--- a/pages/how-it-works/[scenarioId]/[roleId].tsx
+++ b/pages/how-it-works/[scenarioId]/[roleId].tsx
@@ -1,10 +1,21 @@
 import { useState } from "react";
-import type { GetStaticPaths, GetStaticPathsResult, GetStaticProps, NextPage } from "next";
+import type {
+  GetStaticPaths,
+  GetStaticPathsResult,
+  GetStaticProps,
+  NextPage,
+} from "next";
 
 import SideBar from "@/components/walkthroughs/sidebar/SideBar";
 import MainContent from "@/components/walkthroughs/Main/MainContent";
 import { ParsedUrlQuery } from "querystring";
-import { getAllScenarioIds, getScenario, isValidRoleId, isValidScenarioId } from "@/utils/walkthroughs";
+import {
+  getAllScenarioIds,
+  getScenario,
+  getScenarioByRole,
+  isValidRoleId,
+  isValidScenarioId,
+} from "@/utils/walkthroughs";
 import { roles } from "data/roles";
 import { RoleId } from "@/types/roles";
 
@@ -22,7 +33,7 @@ const HowItWorksWalthrough: NextPage<HowItWorksWalthroughProps> = ({
   scenarioId,
   roleId,
 }) => {
-  const scenarioForRole = getScenario(scenarioId)[roleId];
+  const scenarioForRole = getScenarioByRole(scenarioId, roleId);
   const [stage, setStage] = useState(1);
   const sidebarContent = scenarioForRole.sidebarContent?.[stage];
 
@@ -78,6 +89,15 @@ export const getStaticProps: GetStaticProps<
 
   // 404 if the scenario ID or role ID are invalid.
   if (!isValidScenarioId(scenarioId) || !isValidRoleId(roleId)) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const scenario = getScenario(scenarioId);
+
+  // 404 if no scenario defined for the given role.
+  if (!(roleId in scenario.roles)) {
     return {
       notFound: true,
     };

--- a/pages/how-it-works/[scenarioId]/index.tsx
+++ b/pages/how-it-works/[scenarioId]/index.tsx
@@ -135,8 +135,7 @@ export const getStaticProps: GetStaticProps<
     };
   }
 
-  // If there is only one role for this scenario (i.e. it is a generic scenario
-  // or we haven't added all the roles yet) then redirect straight to the
+  // If there is only one role for this scenario then redirect straight to the
   // walkthrough for that role. Note that it is important for this to remain a
   // non-permanent redirect for the case where we add more roles later!
   if (scenarioRoles.length === 1) {

--- a/pages/how-it-works/[scenarioId]/index.tsx
+++ b/pages/how-it-works/[scenarioId]/index.tsx
@@ -1,5 +1,5 @@
 import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
-import { getAllScenarioIds, isValidScenarioId } from "@/utils/walkthroughs";
+import { getAllScenarioIds, getScenario, isValidScenarioId } from "@/utils/walkthroughs";
 import Link from "next/link";
 import { ParsedUrlQuery } from "querystring";
 import { roles } from "data/roles";
@@ -123,6 +123,29 @@ export const getStaticProps: GetStaticProps<
     return {
       notFound: true,
     };
+  }
+
+  const scenario = getScenario(scenarioId);
+  const scenarioRoles = Object.keys(scenario.roles);
+
+  // 404 if no scenarios defined for any role.
+  if (!scenarioRoles.length) {
+    return {
+      notFound: true,
+    };
+  }
+
+  // If there is only one role for this scenario (i.e. it is a generic scenario
+  // or we haven't added all the roles yet) then redirect straight to the
+  // walkthrough for that role. Note that it is important for this to remain a
+  // non-permanent redirect for the case where we add more roles later!
+  if (scenarioRoles.length === 1) {
+    return {
+      redirect: {
+        destination: `/how-it-works/${scenarioId}/${scenarioRoles[0]}`,
+        permanent: false,
+      },
+    }
   }
 
   return {

--- a/types/roles.ts
+++ b/types/roles.ts
@@ -1,4 +1,4 @@
-export type RoleId = 'buyer' | 'seller';
+export type RoleId = 'buyer' | 'seller' | 'generic';
 
 export type Role = {
   label: string;

--- a/types/walkthrough.ts
+++ b/types/walkthrough.ts
@@ -5,7 +5,6 @@ export interface WalkthroughOptions {
   total_offers: string;
   surplus: string;
   stages: number;
-  role: RoleId;
   set_my_price: number;
   allow_button_click: number;
   show_products_quantity?: number;

--- a/types/walkthrough.ts
+++ b/types/walkthrough.ts
@@ -70,8 +70,11 @@ export interface Seller {
 export interface Scenario {
   id: string,
   title: string,
-  buyer: WalkthroughData,
-  seller: WalkthroughData,
+  roles: {
+    buyer?: WalkthroughData;
+    seller?: WalkthroughData;
+    generic?: WalkthroughData;
+  }
 }
 
 export interface Walkthrough {

--- a/types/walkthrough.ts
+++ b/types/walkthrough.ts
@@ -32,7 +32,6 @@ export interface WalkthroughOptions {
 };
 
 export interface WalkthroughData {
-  title: string;
   project_cost: string;
   buyers: Buyer[];
   sellers: Seller[];

--- a/types/walkthrough.ts
+++ b/types/walkthrough.ts
@@ -4,8 +4,6 @@ export interface WalkthroughOptions {
   total_bids: string;
   total_offers: string;
   surplus: string;
-  next_walkthrough: string;
-  next_walkthrough_title: string;
   stages: number;
   role: RoleId;
   set_my_price: number;

--- a/utils/walkthroughs.ts
+++ b/utils/walkthroughs.ts
@@ -1,7 +1,7 @@
 import { RoleId } from "@/types/roles";
 import { roles } from "data/roles";
 import { walkthroughs } from "data/walkthroughs";
-import { Scenario } from "../types/walkthrough";
+import { Scenario, WalkthroughData } from "../types/walkthrough";
 
 const getAllScenarios = (): Scenario[] => {
   const scenarios: Scenario[] = [];
@@ -27,6 +27,20 @@ export const getScenario = (scenarioId: string): Scenario => {
   }
 
   return scenario;
+};
+
+export const getScenarioByRole = (
+  scenarioId: string,
+  roleId: RoleId,
+): WalkthroughData => {
+  const scenario = getScenario(scenarioId);
+  const scenarioByRole = scenario.roles[roleId];
+
+  if (!scenarioByRole) {
+    throw new Error(`No scenario found ID ${scenarioId} and role: ${roleId}`);
+  }
+
+  return scenarioByRole;
 };
 
 export const isValidScenarioId = (

--- a/utils/walkthroughs.ts
+++ b/utils/walkthroughs.ts
@@ -1,7 +1,7 @@
 import { RoleId } from "@/types/roles";
 import { roles } from "data/roles";
 import { walkthroughs } from "data/walkthroughs";
-import { Scenario, WalkthroughData } from "../types/walkthrough";
+import { Scenario, Walkthrough, WalkthroughData } from "../types/walkthrough";
 
 const getAllScenarios = (): Scenario[] => {
   const scenarios: Scenario[] = [];
@@ -41,6 +41,18 @@ export const getScenarioByRole = (
   }
 
   return scenarioByRole;
+};
+
+export const getWalkthroughForScenario = (scenarioId: string): Walkthrough => {
+  const walkthrough = walkthroughs.find((walkthrough) => (
+    walkthrough.scenarios.some((scenario) => scenario.id === scenarioId)
+  ));
+
+  if (!walkthrough) {
+    throw new Error(`No walkthrough found for scenario with ID: ${scenarioId}`);
+  }
+
+  return walkthrough;
 };
 
 export const isValidScenarioId = (

--- a/utils/walkthroughs.ts
+++ b/utils/walkthroughs.ts
@@ -55,6 +55,31 @@ export const getWalkthroughForScenario = (scenarioId: string): Walkthrough => {
   return walkthrough;
 };
 
+export const getNextScenario = (
+  scenarioId: string,
+  roleId: RoleId,
+): Scenario | undefined => {
+  const { scenarios } = getWalkthroughForScenario(scenarioId);
+  const currentIndex = scenarios.findIndex(({ id }) => id === scenarioId);
+
+  if (currentIndex < 0) {
+    throw new Error(`No scenario found with ID: ${scenarioId}`);
+  }
+
+  const nextScenario = scenarios[currentIndex + 1];
+
+  if (!nextScenario) {
+    return;
+  }
+
+  // There may be a next scenario, but not necessarily for the given role.
+  if (!Object.keys(nextScenario.roles).includes(roleId)) {
+    return;
+  }
+
+  return nextScenario;
+};
+
 export const isValidScenarioId = (
   maybeScenarioId?: string,
 ): maybeScenarioId is string => (


### PR DESCRIPTION
A few things going on here:
- Makes it possible to have a walkthrough targeted at either a buyer or seller, but not necessarily both (we have some scenarios that only target one). If only one role is present for a walkthrough clicking the link on the index page will redirect us to the walkthrough for that role.
- Updates the titles in the sidebar to always use the main walkthrough title.
- Fixes the "next walkthrough" mechanism. If we are on scenario 1.1, for example, and a scenario exists for 1.2 then clicking the next button at the end of 1.1 will take us to 1.2. It looks like this is what we want from the designs, which makes sense as then it becomes on continuous flow for the entire walkthrough.
- Adds a placeholder for walkthrough 0, which I was going to start in this PR before realising it's quite different from the rest and will need more changes, so might split that out to avoid this one becoming too much to look at!