### PR TITLE
refactor: unify buyer and seller project data

### DIFF
--- a/components/walkthroughs/Main/Buyer.tsx
+++ b/components/walkthroughs/Main/Buyer.tsx
@@ -2,15 +2,16 @@ import { motion } from "framer-motion";
 
 import { classNames } from "@/utils/index";
 
-import { Buyer as BuyerType, WalkthroughOptions } from "@/types/walkthrough";
+import { Project, WalkthroughOptions } from "@/types/walkthrough";
 import { fadeInDown } from "@/utils/animations";
 
 import HammerIcon from "../icons/HammerIcon";
 import PoundcashTag from "../icons/PoundcashTag";
 import { RoleId } from "@/types/roles";
+import { ProjectTitle } from "./ProjectTitle";
 
 type Props = {
-  buyer: BuyerType;
+  project: Project;
   stage: number;
   options: WalkthroughOptions;
   roleId: RoleId;
@@ -18,17 +19,17 @@ type Props = {
 };
 
 const Buyer = ({
-  buyer,
+  project,
   stage,
   options,
   className = "",
   roleId,
 }: Props) => {
-  const { bid, discount, pays, products, title, id } = buyer;
+  const { cost, discountOrBonus, products, title, isMyProject } = project;
   const { show_bids, show_surpluses, show_final_payments, highlight_me } =
     options;
 
-  const highlightMe = roleId === "buyer" && stage >= highlight_me && id === 1;
+  const highlightMe = roleId === "buyer" && stage >= highlight_me && isMyProject;
 
   return (
     <motion.div
@@ -36,14 +37,12 @@ const Buyer = ({
       initial="hidden"
       animate="visible"
       className={classNames(
-        "bg-brown px-10 py-5 rounded-lg flex gap-x-10 min-w-[736px]",
+        "bg-brown px-10 py-5 rounded-lg flex gap-x-10 min-w-[736px] flex items-center",
         highlightMe ? "border-2 border-black" : "",
         className
       )}
     >
-      <div>
-        <p className="text-black">{title}</p>
-      </div>
+      <ProjectTitle project={project} />
 
       {/* Products */}
       <div className="flex gap-x-10">
@@ -102,7 +101,7 @@ const Buyer = ({
             </div>
             <div className="text-center text-sm relative -mt-2">
               <p className="text-light-grey">Bid</p>
-              {bid && <p>£{bid}</p>}
+              <p>£{cost.toLocaleString()}</p>
             </div>
           </motion.div>
         )}
@@ -120,7 +119,7 @@ const Buyer = ({
             </div>
             <div className="text-center text-sm relative -mt-2">
               <p className="text-light-grey">Discount</p>
-              {discount && <p>£{discount}</p>}
+              <p>£{discountOrBonus.toLocaleString()}</p>
             </div>
           </motion.div>
         )}
@@ -138,7 +137,7 @@ const Buyer = ({
             </div>
             <div className="text-center text-sm relative -mt-2">
               <p className="text-light-grey">Received</p>
-              {pays && <p>£{pays}</p>}
+              <p>£{(cost - discountOrBonus).toLocaleString()}</p>
             </div>
           </motion.div>
         )}

--- a/components/walkthroughs/Main/BuyerLost.tsx
+++ b/components/walkthroughs/Main/BuyerLost.tsx
@@ -1,17 +1,17 @@
-import { Buyer } from "@/types/walkthrough";
+import { Project } from "@/types/walkthrough";
 
 type Props = {
-  buyer: Buyer;
+  project: Project;
 };
 
-const BuyerLost = ({ buyer }: Props) => {
-  const { bid, products, title } = buyer;
+const BuyerLost = ({ project }: Props) => {
+  const { cost, products, title } = project;
 
   return (
     <div className="bg-brown opacity-80 flex items-center justify-between gap-x-5 max-w-[300px] rounded-lg py-2 px-1">
       <div>
         <p>{title}</p>
-        <p>{bid}</p>
+        <p>{cost.toLocaleString()}</p>
       </div>
 
       <div className="flex gap-x-2">

--- a/components/walkthroughs/Main/MainContent.tsx
+++ b/components/walkthroughs/Main/MainContent.tsx
@@ -3,7 +3,7 @@ import { motion } from "framer-motion";
 
 import { container, fadeInDown } from "@/utils/animations";
 
-import { Buyer, WalkthroughData, Seller } from "@/types/walkthrough";
+import { WalkthroughData } from "@/types/walkthrough";
 
 import MarketOutcome from "./MarketOutcome";
 import LoadingOverlay from "./LoadingOverlay";
@@ -42,15 +42,19 @@ const MainContent = ({
     };
   }, [stage, data.options]);
 
-  // Lists excluding user
-  const sellersExcludingUser = data.sellers.filter((seller) => seller.id !== 1);
-  const buyersExcludingUser = data.buyers.filter((buyer) => buyer.id !== 1);
+  const sellerProjectsIncludingUser = roleId === 'seller'
+      ? [...data.sellerProjects, ...data.myProjects]
+      : data.sellerProjects;
 
-  // extract winners and losers for both buyers and sellers
-  const sellersLost = data.sellers.filter((seller) => seller.received === "0");
-  const buyersLost = data.buyers.filter((buyer) => buyer.pays === "0");
-  const sellersWon = data.sellers.filter((seller) => seller.received !== "0");
-  const buyersWon = data.buyers.filter((buyer) => buyer.pays !== "0");
+  const buyerProjectsIncludingUser = roleId === 'buyer'
+    ? [...data.buyerProjects, ...data.myProjects]
+    : data.buyerProjects;
+
+  // Extract winners and losers for both buyers and sellers
+  const sellerProjectsLost = sellerProjectsIncludingUser.filter((project) => !project.accepted);
+  const buyerProjectsLost = buyerProjectsIncludingUser.filter((project) => !project.accepted);
+  const sellerProjectsWon = sellerProjectsIncludingUser.filter((project) => project.accepted);
+  const buyersProjectsWon = buyerProjectsIncludingUser.filter((project) => project.accepted);
 
   return (
     <div className="border-l border-green-dark pt-4 pb-24 w-full relative flex justify-center">
@@ -69,8 +73,8 @@ const MainContent = ({
               animate="visible"
             >
               <ParticipantsList
-                sellers={sellersLost}
-                buyers={buyersLost}
+                sellerProjects={sellerProjectsLost}
+                buyerProjects={buyerProjectsLost}
                 type="losers"
                 stage={stage}
                 data={data}
@@ -88,25 +92,13 @@ const MainContent = ({
                 animate="visible"
                 className="space-y-5"
               >
-                {roleId === "seller" && (
-                  <ParticipantsList
-                    sellers={sellersExcludingUser}
-                    buyers={data.buyers}
-                    stage={stage}
-                    data={data}
-                    roleId={roleId}
-                  />
-                )}
-
-                {roleId === "buyer" && (
-                  <ParticipantsList
-                    sellers={data.sellers}
-                    buyers={buyersExcludingUser}
-                    stage={stage}
-                    data={data}
-                    roleId={roleId}
-                  />
-                )}
+                <ParticipantsList
+                  sellerProjects={data.sellerProjects}
+                  buyerProjects={data.buyerProjects}
+                  stage={stage}
+                  data={data}
+                  roleId={roleId}
+                />
               </motion.div>
             )}
 
@@ -120,8 +112,8 @@ const MainContent = ({
                   className="space-y-5"
                 >
                   <ParticipantsList
-                    sellers={data.sellers}
-                    buyers={data.buyers}
+                    sellerProjects={sellerProjectsIncludingUser}
+                    buyerProjects={buyerProjectsIncludingUser}
                     stage={stage}
                     data={data}
                     roleId={roleId}
@@ -138,8 +130,8 @@ const MainContent = ({
                 className="space-y-5"
               >
                 <ParticipantsList
-                  sellers={sellersWon}
-                  buyers={buyersWon}
+                  sellerProjects={sellerProjectsWon}
+                  buyerProjects={buyersProjectsWon}
                   stage={stage}
                   data={data}
                   roleId={roleId}

--- a/components/walkthroughs/Main/ParticipantsList.tsx
+++ b/components/walkthroughs/Main/ParticipantsList.tsx
@@ -3,37 +3,47 @@ import Seller from "./Seller";
 import BuyerLost from "./BuyerLost";
 import SellerLost from "./SellerLost";
 
-import { WalkthroughData, Seller as SellerType, Buyer as BuyerType } from "@/types/walkthrough";
+import { WalkthroughData, Project} from "@/types/walkthrough";
 import { RoleId } from "@/types/roles";
 
 type Props = {
-  buyers: BuyerType[];
-  sellers: SellerType[];
+  buyerProjects: Project[];
+  sellerProjects: Project[];
   stage: number;
   data: WalkthroughData;
   type?: "winners" | "losers";
   roleId: RoleId;
 };
 
+/**
+ * Sort to bring "my projects" to the top of the list.
+ */
+const sortMyProjects = (projects: Project[]) => (
+  projects.sort((a, b) => Number(b.isMyProject ?? 0) - Number(a.isMyProject ?? 0))
+);
+
 const ParticipantsList = ({
-  buyers,
-  sellers,
+  buyerProjects,
+  sellerProjects,
   stage,
   data,
   roleId,
   type = "winners",
 }: Props) => {
+  const sortedBuyerProjects = sortMyProjects(buyerProjects);
+  const sortedSellerProjects = sortMyProjects(sellerProjects);
+
   return (
     <>
       {type === "winners" && (
         <>
           {/* Sellers */}
           <div className="space-y-5">
-            {sellers.map((seller) => (
+            {sortedSellerProjects.map((project) => (
               <Seller
-                key={seller.id}
+                key={project.title}
                 stage={stage}
-                seller={seller}
+                project={project}
                 options={data.options}
                 roleId={roleId}
               />
@@ -42,11 +52,11 @@ const ParticipantsList = ({
 
           {/* Buyers */}
           <div className="space-y-5">
-            {buyers.map((buyer) => (
+            {sortedBuyerProjects.map((project) => (
               <Buyer
-                key={buyer.id}
+                key={project.title}
                 stage={stage}
-                buyer={buyer}
+                project={project}
                 options={data.options}
                 roleId={roleId}
               />
@@ -59,20 +69,20 @@ const ParticipantsList = ({
         <div className="space-y-2">
           {/* Sellers */}
           <div className="space-y-2">
-            {sellers.map((seller) => (
+            {sortedSellerProjects.map((project) => (
               <SellerLost
-                key={seller.id}
-                seller={seller}
+                key={project.title}
+                project={project}
               />
             ))}
           </div>
 
           {/* Buyers */}
           <div className="space-y-2">
-            {buyers.map((buyer) => (
+            {sortedBuyerProjects.map((project) => (
               <BuyerLost
-                key={buyer.id}
-                buyer={buyer}
+                key={project.title}
+                project={project}
               />
             ))}
           </div>

--- a/components/walkthroughs/Main/ProjectTitle.tsx
+++ b/components/walkthroughs/Main/ProjectTitle.tsx
@@ -1,0 +1,21 @@
+import type { Project } from '@/types/walkthrough';
+import { classNames } from '@/utils/index';
+import { FunctionComponent } from 'react';
+
+type Props = {
+  project: Project;
+}
+
+export const ProjectTitle: FunctionComponent<Props> = ({ project }: Props) => {
+  const { title, subtitle, isMyProject } = project;
+  return (
+    <div className="flex flex-col text-black">
+      <p
+        className={classNames(isMyProject ? 'font-bold' : '')}
+      >
+        {title}
+      </p>
+      {subtitle && <p>{subtitle}</p>}
+    </div>
+  );
+};

--- a/components/walkthroughs/Main/Seller.tsx
+++ b/components/walkthroughs/Main/Seller.tsx
@@ -2,23 +2,24 @@ import { motion } from "framer-motion";
 
 import { classNames } from "@/utils/index";
 
-import { Seller as SellerType, WalkthroughOptions } from "@/types/walkthrough";
+import { Project, WalkthroughOptions } from "@/types/walkthrough";
 import { fadeInDown } from "@/utils/animations";
 
 import HammerIcon from "../icons/HammerIcon";
 import CartPlus from "../icons/CartPlus";
 import { RoleId } from "@/types/roles";
+import { ProjectTitle } from "./ProjectTitle";
 
 type Props = {
-  seller: SellerType;
+  project: Project;
   stage: number;
   options: WalkthroughOptions;
   className?: string;
   roleId: RoleId;
 };
 
-const Seller = ({ seller, stage, options, className = "", roleId }: Props) => {
-  const { offer, bonus, received, products, title, id } = seller;
+const Seller = ({ project, stage, options, className = "", roleId }: Props) => {
+  const { products, title, cost, discountOrBonus, isMyProject } = project;
   const {
     show_offers,
     show_surpluses,
@@ -26,7 +27,7 @@ const Seller = ({ seller, stage, options, className = "", roleId }: Props) => {
     highlight_me,
   } = options;
 
-  const highlightMe = roleId === "seller" && stage >= highlight_me && id === 1;
+  const highlightMe = roleId === "seller" && stage >= highlight_me && isMyProject;
 
   return (
     <motion.div
@@ -34,14 +35,12 @@ const Seller = ({ seller, stage, options, className = "", roleId }: Props) => {
       initial="hidden"
       animate="visible"
       className={classNames(
-        "bg-green-light px-10 py-5 rounded-lg flex gap-x-10 min-w-[736px]",
+        "bg-green-light px-10 py-5 rounded-lg flex gap-x-10 min-w-[736px] flex items-center",
         highlightMe ? "border-2 border-black" : "",
         className
       )}
     >
-      <div>
-        <p className="text-black">{title}</p>
-      </div>
+      <ProjectTitle project={project} />
 
       {/* Products */}
       <div className="flex gap-x-10">
@@ -104,7 +103,7 @@ const Seller = ({ seller, stage, options, className = "", roleId }: Props) => {
             {/* Offer */}
             <div className="text-center text-sm relative -mt-2">
               <p className="text-light-grey">Offer</p>
-              <p>£{offer}</p>
+              <p>£{cost.toLocaleString()}</p>
             </div>
           </motion.div>
         )}
@@ -122,7 +121,7 @@ const Seller = ({ seller, stage, options, className = "", roleId }: Props) => {
             </div>
             <div className="text-center text-sm relative -mt-2">
               <p className="text-light-grey">Bonus</p>
-              {bonus && <p>£{bonus}</p>}
+              <p>£{discountOrBonus.toLocaleString()}</p>
             </div>
           </motion.div>
         )}
@@ -140,7 +139,7 @@ const Seller = ({ seller, stage, options, className = "", roleId }: Props) => {
             </div>
             <div className="text-center text-sm relative -mt-2">
               <p className="text-light-grey">Received</p>
-              {received && <p>£{received}</p>}
+              <p>£{(cost + discountOrBonus).toLocaleString()}</p>
             </div>
           </motion.div>
         )}

--- a/components/walkthroughs/Main/SellerLost.tsx
+++ b/components/walkthroughs/Main/SellerLost.tsx
@@ -1,16 +1,16 @@
-import { Seller } from "@/types/walkthrough";
+import { Project } from "@/types/walkthrough";
 
 type Props = {
-  seller: Seller;
+  project: Project;
 };
-const SellerLost = ({ seller }: Props) => {
-  const { offer, products, title } = seller;
+const SellerLost = ({ project }: Props) => {
+  const { cost, products, title } = project;
 
   return (
     <div className="bg-green-light opacity-80 flex items-center justify-between gap-x-5 max-w-[300px] rounded-lg py-2 px-1">
       <div>
         <p>{title}</p>
-        <p>{offer}</p>
+        <p>{cost.toLocaleString()}</p>
       </div>
 
       <div className="flex gap-x-2">

--- a/components/walkthroughs/sidebar/Details.tsx
+++ b/components/walkthroughs/sidebar/Details.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from "react";
-import { motion, usePresence } from "framer-motion";
+import React from "react";
+import { motion } from "framer-motion";
 
 import { WalkthroughData } from "@/types/walkthrough";
 import { fadeIn } from "@/utils/animations";
@@ -10,6 +10,7 @@ import BiodiversityIconGray from "@/components/walkthroughs/icons/BiodiversityIc
 import NutrientsIcon from "@/components/walkthroughs/icons/NutrientsIcon";
 import { RoleId } from "@/types/roles";
 import { roles } from "data/roles";
+import { classNames } from "@/utils/index";
 
 type Props = {
   next: () => void;
@@ -19,28 +20,13 @@ type Props = {
 };
 
 const Details = ({ data, stage, next, roleId }: Props) => {
-  const [price, setPrice] = useState("");
-
-  // Project cost
-  const projectCost = data.project_cost;
-
-  // User input price
-  const myPrice: string =
-    roleId === "seller"
-      ? data.sellers.find((seller) => seller.id === 1)?.offer!
-      : data.buyers.find((buyer) => buyer.id === 1)?.bid!;
+  const isFormDisabled = stage !== data.options.allow_button_click;
 
   // Proceed to next stage when submit button is clicked
-  const onButtonClick = (e: React.FormEvent) => {
+  const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     next();
   };
-
-  useEffect(() => {
-    if (stage >= data.options.set_my_price) {
-      setPrice(`£${myPrice}`);
-    }
-  }, [stage, data.options]);
 
   return (
     <motion.div
@@ -57,59 +43,67 @@ const Details = ({ data, stage, next, roleId }: Props) => {
         <p>{roles[roleId].label}</p>
       </div>
 
-      <div className="mt-3 flex justify-between">
-        {/* Vector */}
-        <>{roleId === "seller" ? <SellerVector /> : <BuyerVector />}</>
+      <form
+        onSubmit={onSubmit}
+        className="flex flex-col"
+      >
+        <ul>
+          {data.myProjects.map((project, projectIndex) => (
+            <li key={projectIndex}>
+              <div className="mt-3 flex gap-x-3 justify-between items-center">
+                {/* Vector */}
+                <>{roleId === "seller" ? <SellerVector /> : <BuyerVector />}</>
 
-        {/* Credits */}
-        <div className="flex gap-x-2 mt-2">
-          {/* Biodiversity */}
-          <div className="relative">
-            <span className="absolute -right-1 top-0 text-[10px] text-black font-bold border border-black rounded-full bg-white w-[14px] h-[14px] flex justify-center items-center">
-              2
+                {/* Credits */}
+                <div className="flex gap-x-2">
+                  {/* Biodiversity */}
+                  <div className="relative">
+                    <span className="absolute -right-1 top-0 text-[10px] text-black font-bold border border-black rounded-full bg-white w-[14px] h-[14px] flex justify-center items-center">
+                      {project.products.biodiversity}
+                    </span>
+                    <BiodiversityIconGray />
+                  </div>
+                  {/* Nutrients */}
+                  <div className="relative">
+                    <span className="absolute -right-1 top-0 text-[10px] text-black font-bold border border-black rounded-full bg-white w-[14px] h-[14px] flex justify-center items-center">
+                    {project.products.nutrients}
+                    </span>
+                    <NutrientsIcon />
+                  </div>
+                </div>
+
+                {/* Project Cost */}
+                <p className="font-light">£{project.cost.toLocaleString()}</p>
+
+                <input
+                  type="text"
+                  placeholder="Enter offer..."
+                  className="flex-1 text-sm text-center inline-block rounded-lg py-2 bg-[#e8e8e8]"
+                  value={stage >= data.options.set_my_price ? project.cost : ''}
+                />
+              </div>
+            </li>
+          ))}
+        </ul>
+        <div className="relative w-[100px] ml-auto">
+          {stage === data.options.allow_button_click && (
+            <span className="flex h-3 w-3 absolute -right-1 -top-1">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
+              <span className="relative inline-flex rounded-full h-3 w-3 bg-green-500"></span>
             </span>
-            <BiodiversityIconGray />
-          </div>
-          {/* Nutrients */}
-          <div className="relative">
-            <span className="absolute -right-1 top-0 text-[10px] text-black font-bold border border-black rounded-full bg-white w-[14px] h-[14px] flex justify-center items-center">
-              2
-            </span>
-            <NutrientsIcon />
-          </div>
-        </div>
-
-        {/* Project Cost */}
-        <p className="font-light mt-2">£{projectCost}</p>
-
-        {/* Form */}
-        <form
-          className="space-y-4 flex flex-col items-end mt-1"
-          onSubmit={onButtonClick}
-        >
-          <input
-            type="text"
-            placeholder="Enter offer..."
-            className="w-[116px] text-sm text-center inline-block rounded-lg py-2 bg-[#e8e8e8]"
-            value={price}
-          />
-          <div className="relative w-[71px]">
-            {stage === data.options.allow_button_click && (
-              <span className="flex h-3 w-3 absolute right-0 -top-1">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
-                <span className="relative inline-flex rounded-full h-3 w-3 bg-green-500"></span>
-              </span>
+          )}
+          <button
+            type="submit"
+            disabled={isFormDisabled}
+            className={classNames(
+              'w-full rounded-lg bg-[#848484] text-white text-xs py-2',
+              isFormDisabled ? '' : 'hover:bg-black cursor-pointer',
             )}
-            <button
-              type="submit"
-              disabled={stage !== data.options.allow_button_click}
-              className="w-full rounded-lg bg-[#848484] hover:bg-black cursor-pointer text-white text-xs py-2"
-            >
-              Submit
-            </button>
-          </div>
-        </form>
-      </div>
+          >
+            Submit
+          </button>
+        </div>
+      </form>
     </motion.div>
   );
 };

--- a/data/walkthroughs/scenarios/buyers/1.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.1/index.ts
@@ -8,58 +8,54 @@ import { sidebarContent5 } from "./sidebar-content/5";
 import { sidebarContent6 } from "./sidebar-content/6";
 
 export const buyerScenario1_1: WalkthroughData = {
-  "project_cost": "120,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "bid": "120,000",
-      "pays": "107,500",
-      "discount": "12,500",
-      "products": { "biodiversity": 1, "nutrients": 3 }
+      title: 'My Project',
+      cost: 120000,
+      discountOrBonus: 12500,
+      accepted: true,
+      isMyProject: true,
+      products: { biodiversity: 1, nutrients: 3 },
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 100000,
+      discountOrBonus: 7500,
+      accepted: true,
+      products: { biodiversity: 2, nutrients: 2 }
     },
     {
-      "id": 2,
-      "title": "Buyer 1",
-      "bid": "100,000",
-      "pays": "92,500",
-      "discount": "7,500",
-      "products": { "biodiversity": 2, "nutrients": 2 }
-    },
-    {
-      "id": 3,
-      "title": "Buyer 2",
-      "bid": "110,000",
-      "pays": "0",
-      "discount": "0",
-      "products": { "biodiversity": 3, "nutrients": 0 }
+      title: 'Buyer 2',
+      cost: 110000,
+      discountOrBonus: 0,
+      accepted: false,
+      products: { biodiversity: 3, nutrients: 0 }
     }
   ],
-  "sellers": [
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "Seller 1",
-      "offer": "120,000",
-      "received": "0",
-      "bonus": "25,000",
-      "products": { "biodiversity": 3, "nutrients": 1 }
+      title: 'Seller 1',
+      cost: 120000,
+      discountOrBonus: 25000,
+      accepted: false,
+      products: { biodiversity: 3, nutrients: 1 }
     },
     {
-      "id": 2,
-      "title": "Seller 2",
-      "offer": "80,000",
-      "received": "87,500",
-      "bonus": "7,500",
-      "products": { "biodiversity": 2, "nutrients": 1 }
+      title: 'Seller 2',
+      cost: 80000,
+      discountOrBonus: 7500,
+      accepted: true,
+      products: { biodiversity: 2, nutrients: 1 }
     },
     {
-      "id": 3,
-      "title": "Seller 3",
-      "offer": "100,000",
-      "received": "112,500",
-      "bonus": "12,500",
-      "products": { "biodiversity": 1, "nutrients": 4 }
-    }
+      title: 'Seller 3',
+      cost: 100000,
+      discountOrBonus: 12500,
+      accepted: true,
+      products: { biodiversity: 1, nutrients: 4 }
+    },
   ],
   sidebarContent: {
     1: sidebarContent1,

--- a/data/walkthroughs/scenarios/buyers/1.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.2/index.ts
@@ -3,58 +3,54 @@ import { sidebarContent1 } from "./sidebar-content/1";
 import { sidebarContent8 } from "./sidebar-content/8";
 
 export const buyerScenario1_2: WalkthroughData = {
-  "project_cost": "120,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "bid": "100,000",
-      "pays": "97,500",
-      "discount": "2,500",
-      "products": { "biodiversity": 1, "nutrients": 3 }
+      title: 'My Project',
+      cost: 100000,
+      discountOrBonus: 2500,
+      accepted: true,
+      isMyProject: true,
+      products: { biodiversity: 1, nutrients: 3 },
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 100000,
+      discountOrBonus: 7500,
+      accepted: true,
+      products: { biodiversity: 2, nutrients: 2 }
     },
     {
-      "id": 2,
-      "title": "Buyer 1",
-      "bid": "100,000",
-      "pays": "92,500",
-      "discount": "7,500",
-      "products": { "biodiversity": 2, "nutrients": 2 }
-    },
-    {
-      "id": 3,
-      "title": "Buyer 2",
-      "bid": "110,000",
-      "pays": "0",
-      "discount": "0",
-      "products": { "biodiversity": 3, "nutrients": 0 }
+      title: 'Buyer 2',
+      cost: 110000,
+      discountOrBonus: 0,
+      accepted: false,
+      products: { biodiversity: 3, nutrients: 0 }
     }
   ],
-  "sellers": [
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "Seller 1",
-      "offer": "120,000",
-      "received": "0",
-      "bonus": "0",
-      "products": { "biodiversity": 3, "nutrients": 1 }
+      title: 'Seller 1',
+      cost: 120000,
+      discountOrBonus: 0,
+      accepted: false,
+      products: { biodiversity: 3, nutrients: 1 }
     },
     {
-      "id": 2,
-      "title": "Seller 2",
-      "offer": "80,000",
-      "received": "87,500",
-      "bonus": "7,500",
-      "products": { "biodiversity": 2, "nutrients": 1 }
+      title: 'Seller 2',
+      cost: 80000,
+      discountOrBonus: 7500,
+      accepted: true,
+      products: { biodiversity: 2, nutrients: 1 }
     },
     {
-      "id": 3,
-      "title": "Seller 3",
-      "offer": "100,000",
-      "received": "102,500",
-      "bonus": "2,500",
-      "products": { "biodiversity": 1, "nutrients": 4 }
-    }
+      title: 'Seller 3',
+      cost: 100000,
+      discountOrBonus: 2500,
+      accepted: true,
+      products: { biodiversity: 1, nutrients: 4 }
+    },
   ],
   sidebarContent: {
     1: sidebarContent1,

--- a/data/walkthroughs/scenarios/buyers/1.3/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.3/index.ts
@@ -3,57 +3,53 @@ import { sidebarContent1 } from "./sidebar-content/1";
 import { sidebarContent8 } from "./sidebar-content/8";
 
 export const buyerScenario1_3: WalkthroughData = {
-  "project_cost": "120,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "bid": "80,000",
-      "pays": "0",
-      "discount": "0",
-      "products": { "biodiversity": 1, "nutrients": 3 }
+      title: 'My Project',
+      cost: 80000,
+      discountOrBonus: 0,
+      accepted: false,
+      isMyProject: true,
+      products: { biodiversity: 1, nutrients: 3 },
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 100000,
+      accepted: true,
+      discountOrBonus: 2500,
+      products: { biodiversity: 2, nutrients: 2 }
     },
     {
-      "id": 2,
-      "title": "Buyer 1",
-      "bid": "100,000",
-      "pays": "97,500",
-      "discount": "2,500",
-      "products": { "biodiversity": 2, "nutrients": 2 }
-    },
-    {
-      "id": 3,
-      "title": "Buyer 2",
-      "bid": "110,000",
-      "pays": "107,500",
-      "discount": "2,500",
-      "products": { "biodiversity": 3, "nutrients": 0 }
+      title: 'Buyer 2',
+      cost: 110000,
+      accepted: true,
+      discountOrBonus: 2500,
+      products: { biodiversity: 3, nutrients: 0 }
     }
   ],
-  "sellers": [
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "Seller 1",
-      "offer": "120,000",
-      "received": "122,500",
-      "bonus": "2,500",
-      "products": { "biodiversity": 3, "nutrients": 1 }
+      title: 'Seller 1',
+      cost: 120000,
+      accepted: true,
+      discountOrBonus: 2500,
+      products: { biodiversity: 3, nutrients: 1 }
     },
     {
-      "id": 2,
-      "title": "Seller 2",
-      "offer": "80,000",
-      "received": "82,500",
-      "bonus": "2,500",
-      "products": { "biodiversity": 2, "nutrients": 1 }
+      title: 'Seller 2',
+      cost: 80000,
+      accepted: true,
+      discountOrBonus: 2500,
+      products: { biodiversity: 2, nutrients: 1 }
     },
     {
-      "id": 3,
-      "title": "Seller 3",
-      "offer": "100,000",
-      "received": "0",
-      "bonus": "0",
-      "products": { "biodiversity": 1, "nutrients": 4 }
+      title: 'Seller 3',
+      cost: 100000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 1, nutrients: 4 }
     }
   ],
   sidebarContent: {

--- a/data/walkthroughs/scenarios/buyers/2.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.1/index.ts
@@ -5,57 +5,53 @@ import { sidebarContent2 } from "./sidebar-content/2";
 import { sidebarContent3 } from "./sidebar-content/3";
 
 export const buyerScenario2_1: WalkthroughData = {
-  "project_cost": "280,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "bid": "280,000",
-      "pays": "208,000",
-      "discount": "72,000",
-      "products": { "biodiversity": 3, "nutrients": 3 }
+      title: 'My Project',
+      cost: 280000,
+      accepted: true,
+      discountOrBonus: 72000,
+      isMyProject: true,
+      products: { biodiversity: 3, nutrients: 3 }
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 240000,
+      accepted: true,
+      discountOrBonus: 61000,
+      products: { biodiversity: 3, nutrients: 1 }
     },
     {
-      "id": 2,
-      "title": "Buyer 1",
-      "bid": "240,000",
-      "pays": "179,000",
-      "discount": "61,000",
-      "products": { "biodiversity": 3, "nutrients": 1 }
-    },
-    {
-      "id": 3,
-      "title": "Buyer 2",
-      "bid": "260,000",
-      "pays": "215,000",
-      "discount": "45,000",
-      "products": { "biodiversity": 4, "nutrients": 2 }
+      title: 'Buyer 2',
+      cost: 260000,
+      accepted: true,
+      discountOrBonus: 45000,
+      products: { biodiversity: 4, nutrients: 2 }
     }
   ],
-  "sellers": [
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "Seller 1",
-      "offer": "140,000",
-      "received": "224,000",
-      "bonus": "84,000",
-      "products": { "biodiversity": 4, "nutrients": 3 }
+      title: 'Seller 1',
+      cost: 140000,
+      accepted: true,
+      discountOrBonus: 84000,
+      products: { biodiversity: 4, nutrients: 3 }
     },
     {
-      "id": 2,
-      "title": "Seller 2",
-      "offer": "120,000",
-      "received": "173,000",
-      "bonus": "53,000",
-      "products": { "biodiversity": 3, "nutrients": 2 }
+      title: 'Seller 2',
+      cost: 120000,
+      accepted: true,
+      discountOrBonus: 53000,
+      products: { biodiversity: 3, nutrients: 2 }
     },
     {
-      "id": 3,
-      "title": "Seller 3",
-      "offer": "160,000",
-      "received": "205,000",
-      "bonus": "45,000",
-      "products": { "biodiversity": 3, "nutrients": 3 }
+      title: 'Seller 3',
+      cost: 160000,
+      accepted: true,
+      discountOrBonus: 45000,
+      products: { biodiversity: 3, nutrients: 3 }
     }
   ],
   sidebarContent: {

--- a/data/walkthroughs/scenarios/buyers/2.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.2/index.ts
@@ -3,41 +3,39 @@ import { sidebarContent1 } from "./sidebar-content/1";
 import { sidebarContent8 } from "./sidebar-content/8";
 
 export const buyerScenario2_2: WalkthroughData = {
-  "project_cost": "280,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "bid": "280,000",
-      "pays": "150,000",
-      "discount": "130,000",
-      "products": { "biodiversity": 3, "nutrients": 3 }
+      title: 'My Project',
+      cost: 280000,
+      accepted: true,
+      discountOrBonus: 130000,
+      isMyProject: true,
+      products: { biodiversity: 3, nutrients: 3 }
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 240000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 3, nutrients: 1 }
     },
     {
-      "id": 2,
-      "title": "Buyer 1",
-      "bid": "240,000",
-      "pays": "0",
-      "discount": "0",
-      "products": { "biodiversity": 3, "nutrients": 1 }
-    },
-    {
-      "id": 3,
-      "title": "Buyer 2",
-      "bid": "260,000",
-      "pays": "0",
-      "discount": "0",
-      "products": { "biodiversity": 4, "nutrients": 2 }
+      title: 'Buyer 2',
+      cost: 260000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 4, nutrients: 2 }
     }
   ],
-  "sellers": [
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "Seller 1",
-      "offer": "140,000",
-      "received": "150,000",
-      "bonus": "10,000",
-      "products": { "biodiversity": 4, "nutrients": 3 }
+      title: 'Seller 1',
+      cost: 140000,
+      accepted: true,
+      discountOrBonus: 10000,
+      products: { biodiversity: 4, nutrients: 3 }
     }
   ],
   sidebarContent: {

--- a/data/walkthroughs/scenarios/buyers/2.3/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.3/index.ts
@@ -4,41 +4,38 @@ import { sidebarContent8 } from "./sidebar-content/8";
 import {  sidebarContent9 } from "./sidebar-content/9";
 
 export const buyerScenario2_3: WalkthroughData = {
-  "project_cost": "280,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "bid": "280,000",
-      "pays": "150,000",
-      "discount": "130,000",
-      "products": { "biodiversity": 3, "nutrients": 3 }
+      title: 'My Project',
+      cost: 280000,
+      accepted: true,
+      discountOrBonus: 130000,
+      isMyProject: true,
+      products: { biodiversity: 3, nutrients: 3 }
     }
   ],
-  "sellers": [
+  buyerProjects: [],
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "Seller 1",
-      "offer": "140,000",
-      "received": "150,000",
-      "bonus": "10,000",
-      "products": { "biodiversity": 4, "nutrients": 3 }
+      title: 'Seller 1',
+      cost: 140000,
+      accepted: true,
+      discountOrBonus: 10000,
+      products: { biodiversity: 4, nutrients: 3 }
     },
     {
-      "id": 2,
-      "title": "Seller 2",
-      "offer": "120,000",
-      "received": "0",
-      "bonus": "0",
-      "products": { "biodiversity": 3, "nutrients": 2 }
+      title: 'Seller 2',
+      cost: 120000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 3, nutrients: 2 }
     },
     {
-      "id": 3,
-      "title": "Seller 3",
-      "offer": "160,000",
-      "received": "0",
-      "bonus": "0",
-      "products": { "biodiversity": 3, "nutrients": 3 }
+      title: 'Seller 3',
+      cost: 160000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 3, nutrients: 3 }
     }
   ],
   sidebarContent: {

--- a/data/walkthroughs/scenarios/buyers/3.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/3.1/index.ts
@@ -1,57 +1,53 @@
 import { WalkthroughData } from "@/types/walkthrough";
 
 export const buyerScenario3_1: WalkthroughData = {
-  "project_cost": "60,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "bid": "60,000",
-      "pays": "0",
-      "discount": "0",
-      "products": { "biodiversity": 1, "nutrients": 2 }
+      title: 'My Project',
+      cost: 60000,
+      accepted: false,
+      discountOrBonus: 0,
+      isMyProject: true,
+      products: { biodiversity: 1, nutrients: 2 }
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 200000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 5, nutrients: 2 }
     },
     {
-      "id": 2,
-      "title": "Buyer 1",
-      "bid": "200,000",
-      "pays": "0",
-      "discount": "0",
-      "products": { "biodiversity": 5, "nutrients": 2 }
-    },
-    {
-      "id": 3,
-      "title": "Buyer 2",
-      "bid": "300,000",
-      "pays": "250,000",
-      "discount": "50,000",
-      "products": { "biodiversity": 4, "nutrients": 7 }
+      title: 'Buyer 2',
+      cost: 300000,
+      accepted: true,
+      discountOrBonus: 50000,
+      products: { biodiversity: 4, nutrients: 7 }
     }
   ],
-  "sellers": [
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "Seller 1",
-      "offer": "100,000",
-      "received": "0",
-      "bonus": "0",
-      "products": { "biodiversity": 1, "nutrients": 2 }
+      title: 'Seller 1',
+      cost: 100000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 1, nutrients: 2 }
     },
     {
-      "id": 2,
-      "title": "Seller 2",
-      "offer": "150,000",
-      "received": "250,000",
-      "bonus": "100,000",
-      "products": { "biodiversity": 6, "nutrients": 7 }
+      title: 'Seller 2',
+      cost: 150000,
+      accepted: true,
+      discountOrBonus: 100000,
+      products: { biodiversity: 6, nutrients: 7 }
     },
     {
-      "id": 3,
-      "title": "Seller 3",
-      "offer": "210,000",
-      "received": "0",
-      "bonus": "0",
-      "products": { "biodiversity": 4, "nutrients": 4 }
+      title: 'Seller 3',
+      cost: 210000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 4, nutrients: 4 }
     }
   ],
   "options": {

--- a/data/walkthroughs/scenarios/buyers/3.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/3.2/index.ts
@@ -1,57 +1,53 @@
 import { WalkthroughData } from "@/types/walkthrough";
 
 export const buyerScenario3_2: WalkthroughData = {
-  "project_cost": "60,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "bid": "60,000",
-      "pays": "296,000",
-      "discount": "53,000",
-      "products": { "biodiversity": 2, "nutrients": 1 }
+      title: 'My Project',
+      cost: 60000,
+      accepted: true,
+      discountOrBonus: 53000,
+      isMyProject: true,
+      products: { biodiversity: 2, nutrients: 1 }
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 200000,
+      accepted: true,
+      discountOrBonus: 116000,
+      products: { biodiversity: 5, nutrients: 2 }
     },
     {
-      "id": 2,
-      "title": "Buyer 1",
-      "bid": "200,000",
-      "pays": "164,000",
-      "discount": "116,000",
-      "products": { "biodiversity": 5, "nutrients": 2 }
-    },
-    {
-      "id": 3,
-      "title": "Buyer 2",
-      "bid": "300,000",
-      "pays": "73,000",
-      "discount": "73,000",
-      "products": { "biodiversity": 4, "nutrients": 7 }
+      title: 'Buyer 2',
+      cost: 300000,
+      accepted: true,
+      discountOrBonus: 73000,
+      products: { biodiversity: 4, nutrients: 7 }
     }
   ],
-  "sellers": [
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "Seller 1",
-      "offer": "100,000",
-      "received": "0",
-      "bonus": "0",
-      "products": { "biodiversity": 1, "nutrients": 2 }
+      title: 'Seller 1',
+      cost: 100000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 1, nutrients: 2 }
     },
     {
-      "id": 2,
-      "title": "Seller 2",
-      "offer": "150,000",
-      "received": "230,000",
-      "bonus": "110,000",
-      "products": { "biodiversity": 6, "nutrients": 7 }
+      title: 'Seller 2',
+      cost: 150000,
+      accepted: true,
+      discountOrBonus: 110000,
+      products: { biodiversity: 6, nutrients: 7 }
     },
     {
-      "id": 3,
-      "title": "Seller 3",
-      "offer": "210,000",
-      "received": "166,000",
-      "bonus": "86,000",
-      "products": { "biodiversity": 4, "nutrients": 4 }
+      title: 'Seller 3',
+      cost: 210000,
+      accepted: true,
+      discountOrBonus: 86000,
+      products: { biodiversity: 4, nutrients: 4 }
     }
   ],
   "options": {

--- a/data/walkthroughs/scenarios/sellers/1.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.1/index.ts
@@ -7,57 +7,53 @@ import { sidebarContentStage11 } from "./sidebar-content/11";
 import { WalkthroughData } from "@/types/walkthrough";
 
 export const sellerScenario1_1: WalkthroughData = {
-  "project_cost": "60,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "Buyer 1",
-      "bid": "200,000",
-      "pays": "133,000",
-      "discount": "67,000",
-      "products": { "biodiversity": 1, "nutrients": 4 }
+      title: 'My Project',
+      cost: 60000,
+      accepted: true,
+      discountOrBonus: 25000,
+      isMyProject: true,
+      products: { biodiversity: 2, nutrients: 3 }
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 200000,
+      accepted: true,
+      discountOrBonus: 67000,
+      products: { biodiversity: 1, nutrients: 4 }
     },
     {
-      "id": 2,
-      "title": "Buyer 2",
-      "bid": "100,000",
-      "pays": "32,000",
-      "discount": "68,000",
-      "products": { "biodiversity": 0, "nutrients": 2 }
+      title: 'Buyer 2',
+      cost: 100000,
+      accepted: true,
+      discountOrBonus: 68000,
+      products: { biodiversity: 0, nutrients: 2 }
     },
     {
-      "id": 3,
-      "title": "Buyer 3",
-      "bid": "120,000",
-      "pays": "0",
-      "discount": "0",
-      "products": { "biodiversity": 4, "nutrients": 0 }
+      title: 'Buyer 3',
+      cost: 120000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 4, nutrients: 0 }
     }
   ],
-  "sellers": [
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "offer": "60,000",
-      "received": "85,000",
-      "bonus": "25,000",
-      "products": { "biodiversity": 2, "nutrients": 3 }
+      title: 'Seller 1',
+      cost: 120000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 5, nutrients: 2 }
     },
     {
-      "id": 2,
-      "title": "Seller 1",
-      "offer": "120,000",
-      "received": "0",
-      "bonus": "0",
-      "products": { "biodiversity": 5, "nutrients": 2 }
-    },
-    {
-      "id": 3,
-      "title": "Seller 2",
-      "offer": "50,000",
-      "received": "80,000",
-      "bonus": "30,000",
-      "products": { "biodiversity": 0, "nutrients": 3 }
+      title: 'Seller 2',
+      cost: 50000,
+      accepted: true,
+      discountOrBonus: 30000,
+      products: { biodiversity: 0, nutrients: 3 }
     }
   ],
   sidebarContent: {

--- a/data/walkthroughs/scenarios/sellers/1.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.2/index.ts
@@ -3,57 +3,52 @@ import { sidebarContentStage1 } from "./sidebar-content/1";
 import { sidebarContentStage8 } from "./sidebar-content/8";
 
 export const sellerScenario1_2: WalkthroughData = {
-  "project_cost": "60,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "Buyer 1",
-      "bid": "200,000",
-      "pays": "133,000",
-      "discount": "67,000",
-      "products": { "biodiversity": 1, "nutrients": 4 }
+      title: 'My Project',
+      cost: 80000,
+      accepted: true,
+      discountOrBonus: 25000,
+      products: { biodiversity: 2, nutrients: 3 }
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 200000,
+      accepted: true,
+      discountOrBonus: 67000,
+      products: { biodiversity: 1, nutrients: 4 }
     },
     {
-      "id": 2,
-      "title": "Buyer 2",
-      "bid": "100,000",
-      "pays": "32,000",
-      "discount": "68,000",
-      "products": { "biodiversity": 0, "nutrients": 2 }
+      title: 'Buyer 2',
+      cost: 100000,
+      accepted: true,
+      discountOrBonus: 68000,
+      products: { biodiversity: 0, nutrients: 2 }
     },
     {
-      "id": 3,
-      "title": "Buyer 3",
-      "bid": "120,000",
-      "pays": "0",
-      "discount": "0",
-      "products": { "biodiversity": 4, "nutrients": 0 }
+      title: 'Buyer 3',
+      cost: 120000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 4, nutrients: 0 }
     }
   ],
-  "sellers": [
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "offer": "80,000",
-      "received": "85,000",
-      "bonus": "25,000",
-      "products": { "biodiversity": 2, "nutrients": 3 }
+      title: 'Seller 1',
+      cost: 120000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 5, nutrients: 2 }
     },
     {
-      "id": 2,
-      "title": "Seller 1",
-      "offer": "120,000",
-      "received": "0",
-      "bonus": "0",
-      "products": { "biodiversity": 5, "nutrients": 2 }
-    },
-    {
-      "id": 3,
-      "title": "Seller 2",
-      "offer": "50,000",
-      "received": "80,000",
-      "bonus": "30,000",
-      "products": { "biodiversity": 0, "nutrients": 3 }
+      title: 'Seller 2',
+      cost: 50000,
+      accepted: true,
+      discountOrBonus: 30000,
+      products: { biodiversity: 0, nutrients: 3 }
     }
   ],
   sidebarContent: {

--- a/data/walkthroughs/scenarios/sellers/1.3/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.3/index.ts
@@ -3,57 +3,52 @@ import { sidebarContentStage1 } from "./sidebar-content/1";
 import { sidebarContentStage8 } from "./sidebar-content/8";
 
 export const sellerScenario1_3: WalkthroughData = {
-  "project_cost": "60,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "Buyer 1",
-      "bid": "200,000",
-      "pays": "162,000",
-      "discount": "37,000",
-      "products": { "biodiversity": 1, "nutrients": 4 }
+      title: 'My Project',
+      cost: 100000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 2, nutrients: 3 }
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 200000,
+      accepted: true,
+      discountOrBonus: 37000,
+      products: { biodiversity: 1, nutrients: 4 }
     },
     {
-      "id": 2,
-      "title": "Buyer 2",
-      "bid": "100,000",
-      "pays": "0",
-      "discount": "0",
-      "products": { "biodiversity": 0, "nutrients": 2 }
+      title: 'Buyer 2',
+      cost: 100000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 0, nutrients: 2 }
     },
     {
-      "id": 3,
-      "title": "Buyer 3",
-      "bid": "120,000",
-      "pays": "99,000",
-      "discount": "21,000",
-      "products": { "biodiversity": 4, "nutrients": 0 }
+      title: 'Buyer 3',
+      cost: 120000,
+      accepted: true,
+      discountOrBonus: 21000,
+      products: { biodiversity: 4, nutrients: 0 }
     }
   ],
-  "sellers": [
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "offer": "100,000",
-      "received": "0",
-      "bonus": "0",
-      "products": { "biodiversity": 2, "nutrients": 3 }
+      title: 'Seller 1',
+      cost: 120000,
+      accepted: true,
+      discountOrBonus: 21000,
+      products: { biodiversity: 5, nutrients: 2 }
     },
     {
-      "id": 2,
-      "title": "Seller 1",
-      "offer": "120,000",
-      "received": "141,000",
-      "bonus": "21,000",
-      "products": { "biodiversity": 5, "nutrients": 2 }
-    },
-    {
-      "id": 3,
-      "title": "Seller 2",
-      "offer": "50,000",
-      "received": "121,000",
-      "bonus": "71,000",
-      "products": { "biodiversity": 0, "nutrients": 3 }
+      title: 'Seller 2',
+      cost: 50000,
+      accepted: true,
+      discountOrBonus: 71000,
+      products: { biodiversity: 0, nutrients: 3 }
     }
   ],
   sidebarContent: {

--- a/data/walkthroughs/scenarios/sellers/2.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.1/index.ts
@@ -5,57 +5,53 @@ import { sidebarContentStage10 } from "./sidebar-content/10";
 import { WalkthroughData } from "@/types/walkthrough";
 
 export const sellerScenario2_1: WalkthroughData = {
-  "project_cost": "140,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "Buyer 1",
-      "bid": "240,000",
-      "pays": "162,000",
-      "discount": "61,000",
-      "products": { "biodiversity": 3, "nutrients": 1 }
+      title: 'My Project',
+      cost: 140000,
+      accepted: true,
+      discountOrBonus: 84000,
+      isMyProject: true,
+      products: { biodiversity: 4, nutrients: 3 }
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 240000,
+      accepted: true,
+      discountOrBonus: 61000,
+      products: { biodiversity: 3, nutrients: 1 }
     },
     {
-      "id": 2,
-      "title": "Buyer 2",
-      "bid": "260,000",
-      "pays": "162,000",
-      "discount": "45,000",
-      "products": { "biodiversity": 4, "nutrients": 2 }
+      title: 'Buyer 2',
+      cost: 260000,
+      accepted: true,
+      discountOrBonus: 45000,
+      products: { biodiversity: 4, nutrients: 2 }
     },
     {
-      "id": 3,
-      "title": "Buyer 3",
-      "bid": "280,000",
-      "pays": "162,000",
-      "discount": "72,000",
-      "products": { "biodiversity": 3, "nutrients": 3 }
+      title: 'Buyer 3',
+      cost: 280000,
+      accepted: true,
+      discountOrBonus: 72000,
+      products: { biodiversity: 3, nutrients: 3 }
     }
   ],
-  "sellers": [
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "offer": "140,000",
-      "received": "141,000",
-      "bonus": "84,000",
-      "products": { "biodiversity": 4, "nutrients": 3 }
+      title: 'Seller 1',
+      cost: 120000,
+      accepted: true,
+      discountOrBonus: 53000,
+      products: { biodiversity: 3, nutrients: 2 }
     },
     {
-      "id": 2,
-      "title": "Seller 1",
-      "offer": "120,000",
-      "received": "141,000",
-      "bonus": "53,000",
-      "products": { "biodiversity": 3, "nutrients": 2 }
-    },
-    {
-      "id": 3,
-      "title": "Seller 2",
-      "offer": "160,000",
-      "received": "141,000",
-      "bonus": "45,000",
-      "products": { "biodiversity": 3, "nutrients": 3 }
+      title: 'Seller 2',
+      cost: 160000,
+      accepted: true,
+      discountOrBonus: 45000,
+      products: { biodiversity: 3, nutrients: 3 }
     }
   ],
   sidebarContent: {

--- a/data/walkthroughs/scenarios/sellers/2.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.2/index.ts
@@ -3,41 +3,39 @@ import { sidebarContentStage1 } from "./sidebar-content/1";
 import { sidebarContentStage8 } from "./sidebar-content/8";
 
 export const sellerScenario2_2: WalkthroughData = {
-  "project_cost": "140,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "Buyer 1",
-      "bid": "280,000",
-      "pays": "150,000",
-      "discount": "130,000",
-      "products": { "biodiversity": 3, "nutrients": 3 }
+      title: 'My Project',
+      cost: 140000,
+      accepted: true,
+      discountOrBonus: 10000,
+      isMyProject: true,
+      products: { biodiversity: 4, nutrients: 3 }
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 280000,
+      accepted: true,
+      discountOrBonus: 130000,
+      products: { biodiversity: 3, nutrients: 3 }
     }
   ],
-  "sellers": [
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "offer": "140,000",
-      "received": "150,000",
-      "bonus": "10,000",
-      "products": { "biodiversity": 4, "nutrients": 3 }
+      title: 'Seller 1',
+      cost: 120000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 3, nutrients: 2 }
     },
     {
-      "id": 2,
-      "title": "Seller 1",
-      "offer": "120,000",
-      "received": "0",
-      "bonus": "0",
-      "products": { "biodiversity": 3, "nutrients": 2 }
-    },
-    {
-      "id": 3,
-      "title": "Seller 2",
-      "offer": "160,000",
-      "received": "0",
-      "bonus": "0",
-      "products": { "biodiversity": 3, "nutrients": 3 }
+      title: 'Seller 2',
+      cost: 160000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 3, nutrients: 3 }
     }
   ],
   sidebarContent: {

--- a/data/walkthroughs/scenarios/sellers/2.3/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.3/index.ts
@@ -4,43 +4,40 @@ import { sidebarContentStage8 } from "./sidebar-content/8";
 import { sidebarContentStage9 } from "./sidebar-content/9";
 
 export const sellerScenario2_3: WalkthroughData = {
-  "project_cost": "140,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "Buyer 1",
-      "bid": "240,000",
-      "pays": "0",
-      "discount": "0",
-      "products": { "biodiversity": 3, "nutrients": 1 }
-    },
-    {
-      "id": 2,
-      "title": "Buyer 2",
-      "bid": "260,000",
-      "pays": "0",
-      "discount": "0",
-      "products": { "biodiversity": 4, "nutrients": 2 }
-    },
-    {
-      "id": 3,
-      "title": "Buyer 3",
-      "bid": "280,000",
-      "pays": "270,000",
-      "discount": "10,000",
-      "products": { "biodiversity": 3, "nutrients": 3 }
+      title: 'My Project',
+      cost: 140000,
+      accepted: true,
+      discountOrBonus: 130000,
+      isMyProject: true,
+      products: { biodiversity: 4, nutrients: 3 }
     }
   ],
-  "sellers": [
+  buyerProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "offer": "140,000",
-      "received": "270,000",
-      "bonus": "130,000",
-      "products": { "biodiversity": 4, "nutrients": 3 }
+      title: 'Buyer 1',
+      cost: 240000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 3, nutrients: 1 }
+    },
+    {
+      title: 'Buyer 2',
+      cost: 260000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 4, nutrients: 2 }
+    },
+    {
+      title: 'Buyer 3',
+      cost: 280000,
+      accepted: true,
+      discountOrBonus: 10000,
+      products: { biodiversity: 3, nutrients: 3 }
     }
   ],
+  sellerProjects: [],
   sidebarContent: {
     1: sidebarContentStage1,
     8: sidebarContentStage8,

--- a/data/walkthroughs/scenarios/sellers/3.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/3.1/index.ts
@@ -5,57 +5,53 @@ import { sidebarContentStage10 } from "./sidebar-content/10";
 import { WalkthroughData } from "@/types/walkthrough";
 
 export const sellerScenario3_1: WalkthroughData = {
-  "project_cost": "100,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "Buyer 1",
-      "bid": "350,000",
-      "pays": "0",
-      "discount": "0",
-      "products": { "biodiversity": 6, "nutrients": 8 }
+      title: 'My Project',
+      cost: 100000,
+      accepted: false,
+      discountOrBonus: 0,
+      isMyProject: true,
+      products: { biodiversity: 2, nutrients: 1 }
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 350000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 6, nutrients: 8 }
     },
     {
-      "id": 2,
-      "title": "Buyer 2",
-      "bid": "280,000",
-      "pays": "162,000",
-      "discount": "45,000",
-      "products": { "biodiversity": 4, "nutrients": 4 }
+      title: 'Buyer 2',
+      cost: 280000,
+      accepted: true,
+      discountOrBonus: 45000,
+      products: { biodiversity: 4, nutrients: 4 }
     },
     {
-      "id": 3,
-      "title": "Buyer 3",
-      "bid": "120,000",
-      "pays": "162,000",
-      "discount": "72,000",
-      "products": { "biodiversity": 3, "nutrients": 0 }
+      title: 'Buyer 3',
+      cost: 120000,
+      accepted: true,
+      discountOrBonus: 72000,
+      products: { biodiversity: 3, nutrients: 0 }
     }
   ],
-  "sellers": [
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "offer": "100,000",
-      "received": "0",
-      "bonus": "0",
-      "products": { "biodiversity": 2, "nutrients": 1 }
+      title: 'Seller 1',
+      cost: 120000,
+      accepted: true,
+      discountOrBonus: 53000,
+      products: { biodiversity: 7, nutrients: 6 }
     },
     {
-      "id": 2,
-      "title": "Seller 1",
-      "offer": "120,000",
-      "received": "141,000",
-      "bonus": "53,000",
-      "products": { "biodiversity": 7, "nutrients": 6 }
-    },
-    {
-      "id": 3,
-      "title": "Seller 2",
-      "offer": "80,000",
-      "received": "0",
-      "bonus": "0",
-      "products": { "biodiversity": 5, "nutrients": 4 }
+      title: 'Seller 2',
+      cost: 80000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 5, nutrients: 4 }
     }
   ],
   sidebarContent: {

--- a/data/walkthroughs/scenarios/sellers/3.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/3.2/index.ts
@@ -4,57 +4,53 @@ import { sidebarContentStage8 } from "./sidebar-content/8";
 import { sidebarContentStage9 } from "./sidebar-content/9";
 
 export const sellerScenario3_2: WalkthroughData = {
-  "project_cost": "100,000",
-  "buyers": [
+  myProjects: [
     {
-      "id": 1,
-      "title": "Buyer 1",
-      "bid": "350,000",
-      "pays": "296,000",
-      "discount": "53,000",
-      "products": { "biodiversity": 6, "nutrients": 8 }
+      title: 'My Project',
+      cost: 100000,
+      accepted: true,
+      discountOrBonus: 37000,
+      isMyProject: true,
+      products: { biodiversity: 1, nutrients: 2 }
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 350000,
+      accepted: true,
+      discountOrBonus: 53000,
+      products: { biodiversity: 6, nutrients: 8 }
     },
     {
-      "id": 2,
-      "title": "Buyer 2",
-      "bid": "280,000",
-      "pays": "164,000",
-      "discount": "116,000",
-      "products": { "biodiversity": 3, "nutrients": 4 }
+      title: 'Buyer 2',
+      cost: 280000,
+      accepted: true,
+      discountOrBonus: 116000,
+      products: { biodiversity: 3, nutrients: 4 }
     },
     {
-      "id": 3,
-      "title": "Buyer 3",
-      "bid": "120,000",
-      "pays": "73,000",
-      "discount": "73,000",
-      "products": { "biodiversity": 3, "nutrients": 0 }
+      title: 'Buyer 3',
+      cost: 120000,
+      accepted: true,
+      discountOrBonus: 73000,
+      products: { biodiversity: 3, nutrients: 0 }
     }
   ],
-  "sellers": [
+  sellerProjects: [
     {
-      "id": 1,
-      "title": "My Project",
-      "offer": "100,000",
-      "received": "137,000",
-      "bonus": "37,000",
-      "products": { "biodiversity": 1, "nutrients": 2 }
+      title: 'Seller 1',
+      cost: 120000,
+      accepted: true,
+      discountOrBonus: 110000,
+      products: { biodiversity: 7, nutrients: 6 }
     },
     {
-      "id": 2,
-      "title": "Seller 1",
-      "offer": "120,000",
-      "received": "230,000",
-      "bonus": "110,000",
-      "products": { "biodiversity": 7, "nutrients": 6 }
-    },
-    {
-      "id": 3,
-      "title": "Seller 2",
-      "offer": "80,000",
-      "received": "166,000",
-      "bonus": "86,000",
-      "products": { "biodiversity": 5, "nutrients": 4 }
+      title: 'Seller 2',
+      cost: 80000,
+      accepted: true,
+      discountOrBonus: 86000,
+      products: { biodiversity: 5, nutrients: 4 }
     }
   ],
   sidebarContent: {

--- a/types/walkthrough.ts
+++ b/types/walkthrough.ts
@@ -1,5 +1,3 @@
-import { RoleId } from "./roles";
-
 export interface WalkthroughOptions {
   total_bids: string;
   total_offers: string;
@@ -30,37 +28,29 @@ export interface WalkthroughOptions {
   highlight_me: number;
 };
 
-export interface WalkthroughData {
-  project_cost: string;
-  buyers: Buyer[];
-  sellers: Seller[];
-  sidebarContent?: {
-    [key: number]: JSX.Element;
-  },
-  options: WalkthroughOptions;
-}
-
-export interface Buyer {
-  id: number;
-  title: string;
-  bid: string;
-  pays: string;
-  discount: string;
-  products: Products;
-}
-
 export interface Products {
   biodiversity: number;
   nutrients: number;
 }
 
-export interface Seller {
-  id: number;
+export interface Project {
   title: string;
-  offer: string;
-  received: string;
-  bonus: string;
+  subtitle?: string;
+  cost: number;
+  accepted: boolean,
+  isMyProject?: boolean;
+  discountOrBonus: number;
   products: Products;
+}
+
+export interface WalkthroughData {
+  myProjects: [Project, ...Project[]]; // One or more
+  buyerProjects: Project[];
+  sellerProjects: Project[];
+  sidebarContent?: {
+    [key: number]: JSX.Element;
+  },
+  options: WalkthroughOptions;
 }
 
 export interface Scenario {


### PR DESCRIPTION
Previously, we had the `Seller` and `Buyer` data defined using separate models, with slightly different fields. In fact, whether we are buying or selling the data is effectively the same, just with different labels in the UI. So, perhaps the main change in this PR is to unify those two things to use the same model, where each project has the following fields:

https://github.com/curiousways/marketdesign/blob/f48597ab2a66a4ac2d3b14b4f10a0b6e61606205/types/walkthrough.ts#L36-L44

The `cost` and `discountOrBonus` are defined as numbers, meaning we can actually calculate the final "paid" or "received" values, rather than fiddling about and trying to keep all those string values in sync, which should make adding future walkthroughs a little easier.

A separate section has been split out for `myProjects`, largely to enable this sort of multi-project behaviour coming up in walkthrough 5:

![image](https://user-images.githubusercontent.com/5636273/201963086-ffb6df88-2d2d-44b3-90cc-4f3c409caeff.png)

For now, `accepted` is a boolean, but I could see that being extended to also accept a number, in order to support the "75% accepted" bit. I'll do that as part of adding the first walkthrough that needs it, for the time being I'm just trying to make sure that all the existing walkthroughs behave correctly!

---

Note that this PR branches off https://github.com/curiousways/marketdesign/pull/12, so probably makes sense to merge that first!