### PR TITLE
Walkthroughs 5 seller

### DIFF
--- a/components/walkthroughs/Main/MainContent.tsx
+++ b/components/walkthroughs/Main/MainContent.tsx
@@ -42,12 +42,14 @@ const MainContent = ({
     };
   }, [stage, data.options]);
 
+  const activeUserProjects = data.myProjects.filter((project) => !project.isInactive);
+
   const sellerProjectsIncludingUser = roleId === 'seller'
-      ? [...data.sellerProjects, ...data.myProjects]
+      ? [...data.sellerProjects, ...activeUserProjects]
       : data.sellerProjects;
 
   const buyerProjectsIncludingUser = roleId === 'buyer'
-    ? [...data.buyerProjects, ...data.myProjects]
+    ? [...data.buyerProjects, ...activeUserProjects]
     : data.buyerProjects;
 
   // Extract winners and losers for both buyers and sellers

--- a/components/walkthroughs/Main/ParticipantsList.tsx
+++ b/components/walkthroughs/Main/ParticipantsList.tsx
@@ -67,9 +67,9 @@ const ParticipantsList = ({
       )}
 
       {type === "losers" && (
-        <div className="space-y-2 px-1">
+        <>
           {/* Sellers */}
-          <div className="space-y-2">
+          <div className="space-y-2 px-1">
             {sortedSellerProjects.map((project) => (
               <SellerLost
                 key={project.title}
@@ -79,7 +79,7 @@ const ParticipantsList = ({
           </div>
 
           {/* Buyers */}
-          <div className="space-y-2">
+          <div className="space-y-2 px-1">
             {sortedBuyerProjects.map((project) => (
               <BuyerLost
                 key={project.title}
@@ -87,7 +87,7 @@ const ParticipantsList = ({
               />
             ))}
           </div>
-        </div>
+        </>
       )}
     </>
   );

--- a/components/walkthroughs/Main/ParticipantsList.tsx
+++ b/components/walkthroughs/Main/ParticipantsList.tsx
@@ -67,27 +67,32 @@ const ParticipantsList = ({
       )}
 
       {type === "losers" && (
-        <>
+        <div className="px-2">
           {/* Sellers */}
-          <div className="space-y-2 px-1">
-            {sortedSellerProjects.map((project) => (
+          {sortedSellerProjects.map((project) => (
+            <div
+              key={project.title}
+              className="mb-2"
+            >
               <SellerLost
-                key={project.title}
                 project={project}
               />
-            ))}
-          </div>
+            </div>
+          ))}
 
           {/* Buyers */}
-          <div className="space-y-2 px-1">
-            {sortedBuyerProjects.map((project) => (
+          {sortedBuyerProjects.map((project) => (
+            <div
+              key={project.title}
+              className="mb-2"
+            >
               <BuyerLost
                 key={project.title}
                 project={project}
               />
-            ))}
-          </div>
-        </>
+            </div>
+          ))}
+        </div>
       )}
     </>
   );

--- a/components/walkthroughs/sidebar/Details.tsx
+++ b/components/walkthroughs/sidebar/Details.tsx
@@ -40,7 +40,9 @@ const Details = ({ data, stage, next, roleId }: Props) => {
       className="border-2 border-black px-5 py-4 rounded-lg w-full"
     >
       <div className="text-black text-xl">
-        <p className="font-bold">My Project</p>
+        <p className="font-bold">
+          My Project{data.myProjects.length ? 's' : ''}
+        </p>
         <p>{roles[roleId].label}</p>
       </div>
 
@@ -50,8 +52,19 @@ const Details = ({ data, stage, next, roleId }: Props) => {
       >
         <ul>
           {data.myProjects.map((project, projectIndex) => (
-            <li key={projectIndex}>
-              <div className="mt-3 flex gap-x-3 justify-between items-center">
+            <li
+              key={projectIndex}
+              className={classNames(
+                'mt-3',
+                stage >= data.options.set_my_price && project.isInactive ? 'opacity-30' : '',
+              )}
+            >
+              {!!data.myProjects.length && !!project.subtitle && (
+                <span className="flex justify-end	text-sm underline">
+                  {project.subtitle}
+                </span>
+              )}
+              <div className="flex gap-x-3 justify-between items-center">
                 {/* Vector */}
                 <>{roleId === "seller" ? <SellerVector /> : <BuyerVector />}</>
 
@@ -76,17 +89,19 @@ const Details = ({ data, stage, next, roleId }: Props) => {
                 {/* Project Cost */}
                 <p className="font-light">£{project.cost.toLocaleString()}</p>
 
-                <input
-                  type="text"
-                  placeholder="Enter offer..."
-                  className="flex-1 text-sm text-center inline-block rounded-lg py-2 bg-[#e8e8e8]"
-                  value={stage >= data.options.set_my_price ? project.cost : ''}
-                />
+                <div className="flex-1">
+                  <input
+                    type="text"
+                    placeholder="Enter offer..."
+                    className="w-full text-sm inline-block rounded-lg py-2 px-3 bg-[#e8e8e8]"
+                    value={stage >= data.options.set_my_price && !project.isInactive ? project.cost : ''}
+                  />
+                </div>
               </div>
             </li>
           ))}
         </ul>
-        <div className="flex items-center">
+        <div className="flex items-center mt-3">
           {data.options.show_divisible_input && (
             <label
               className={classNames(

--- a/data/walkthroughs/index.ts
+++ b/data/walkthroughs/index.ts
@@ -17,6 +17,7 @@ import { sellerScenario2_2 } from "./scenarios/sellers/2.2";
 import { sellerScenario2_3 } from "./scenarios/sellers/2.3";
 import { sellerScenario3_1 } from "./scenarios/sellers/3.1";
 import { sellerScenario3_2 } from "./scenarios/sellers/3.2";
+import { sellerScenario4_1, sellerScenario5_1 } from "./scenarios/sellers/5.1";
 
 export const walkthroughs: Walkthrough[] = [
   {
@@ -131,5 +132,18 @@ export const walkthroughs: Walkthrough[] = [
         },
       },
     ]
+  },
+  {
+    id: 5,
+    title: 'Project Options for the Same Field',
+    scenarios: [
+      {
+        id: '5.1',
+        title: 'Project 1 Bid',
+        roles: {
+          seller: sellerScenario5_1,
+        },
+      },
+    ],
   },
 ];

--- a/data/walkthroughs/index.ts
+++ b/data/walkthroughs/index.ts
@@ -19,6 +19,7 @@ import { sellerScenario3_1 } from "./scenarios/sellers/3.1";
 import { sellerScenario3_2 } from "./scenarios/sellers/3.2";
 import { sellerScenario5_1 } from "./scenarios/sellers/5.1";
 import { sellerScenario5_2 } from "./scenarios/sellers/5.2";
+import { sellerScenario5_3 } from "./scenarios/sellers/5.3";
 
 export const walkthroughs: Walkthrough[] = [
   {
@@ -150,6 +151,13 @@ export const walkthroughs: Walkthrough[] = [
         title: 'Project 2 Bid',
         roles: {
           seller: sellerScenario5_2,
+        },
+      },
+      {
+        id: '5.3',
+        title: '5.3 Project 1 & Project 2 XOR Bid',
+        roles: {
+          seller: sellerScenario5_3,
         },
       },
     ],

--- a/data/walkthroughs/index.ts
+++ b/data/walkthroughs/index.ts
@@ -17,7 +17,8 @@ import { sellerScenario2_2 } from "./scenarios/sellers/2.2";
 import { sellerScenario2_3 } from "./scenarios/sellers/2.3";
 import { sellerScenario3_1 } from "./scenarios/sellers/3.1";
 import { sellerScenario3_2 } from "./scenarios/sellers/3.2";
-import { sellerScenario4_1, sellerScenario5_1 } from "./scenarios/sellers/5.1";
+import { sellerScenario5_1 } from "./scenarios/sellers/5.1";
+import { sellerScenario5_2 } from "./scenarios/sellers/5.2";
 
 export const walkthroughs: Walkthrough[] = [
   {
@@ -142,6 +143,13 @@ export const walkthroughs: Walkthrough[] = [
         title: 'Project 1 Bid',
         roles: {
           seller: sellerScenario5_1,
+        },
+      },
+      {
+        id: '5.2',
+        title: 'Project 2 Bid',
+        roles: {
+          seller: sellerScenario5_2,
         },
       },
     ],

--- a/data/walkthroughs/scenarios/sellers/5.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/5.1/index.ts
@@ -1,0 +1,99 @@
+import { sidebarContentStage1 } from "./sidebar-content/1";
+import { sidebarContentStage2 } from "./sidebar-content/2";
+import { sidebarContentStage3 } from "./sidebar-content/3";
+import { sidebarContentStage12 } from "./sidebar-content/12";
+import { WalkthroughData } from "@/types/walkthrough";
+import { sidebarContentStage4 } from "./sidebar-content/4";
+import { sidebarContentStage5 } from "./sidebar-content/5";
+
+export const sellerScenario5_1: WalkthroughData = {
+  myProjects: [
+    {
+      title: 'My Project',
+      subtitle: 'Project 1',
+      cost: 140000,
+      discountOrBonus: 4400,
+      accepted: true,
+      isMyProject: true,
+      products: { biodiversity: 1, nutrients: 3 },
+    },
+    {
+      title: 'My Project',
+      subtitle: 'Project 2',
+      cost: 180000,
+      discountOrBonus: 0,
+      accepted: false,
+      isMyProject: true,
+      isInactive: true,
+      products: { biodiversity: 2, nutrients: 5 },
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 220000,
+      accepted: true,
+      discountOrBonus: 7000,
+      products: { biodiversity: 1, nutrients: 4 }
+    },
+    {
+      title: 'Buyer 2',
+      cost: 120000,
+      accepted: true,
+      discountOrBonus: 44000,
+      products: { biodiversity: 3, nutrients: 0 }
+    },
+    {
+      title: 'Buyer 3',
+      cost: 100000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 1, nutrients: 1 }
+    }
+  ],
+  sellerProjects: [
+    {
+      title: 'Seller 1',
+      cost: 90000,
+      accepted: true,
+      discountOrBonus: 14000,
+      products: { biodiversity: 1, nutrients: 3 }
+    },
+  ],
+  sidebarContent: {
+    1: sidebarContentStage1,
+    2: sidebarContentStage2,
+    3: sidebarContentStage3,
+    4: sidebarContentStage4,
+    5: sidebarContentStage5,
+    12: sidebarContentStage12,
+  },
+  options: {
+    total_bids: '340,000',
+    total_offers: '230,000',
+    surplus: '110,000',
+    stages: 12,
+    set_my_price: 5,
+    allow_button_click: 5,
+    show_calculating_overlay: [7, 9, 11],
+    show_details_widget: 2,
+    show_solve_market: 6,
+    show_market_outcome: 8,
+    show_calculating_winners: 7,
+    show_distributing_surplus: 9,
+    show_calculating_final: 11,
+    show_surpluses: 10,
+    show_final_payments: 12,
+    show_balanced_market: 12,
+    show_bids: 3,
+    show_offers: 3,
+    show_maps: true,
+    show_full_map: 1,
+    show_highlighted_map: 2,
+    show_participants: 4,
+    hide_next_button: [5, 6, 7, 8, 9],
+    hide_prev_button: [1],
+    show_losers: 8,
+    highlight_me: 6,
+  }
+}

--- a/data/walkthroughs/scenarios/sellers/5.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/5.1/index.ts
@@ -12,7 +12,7 @@ export const sellerScenario5_1: WalkthroughData = {
       title: 'My Project',
       subtitle: 'Project 1',
       cost: 140000,
-      discountOrBonus: 4400,
+      discountOrBonus: 44000,
       accepted: true,
       isMyProject: true,
       products: { biodiversity: 1, nutrients: 3 },

--- a/data/walkthroughs/scenarios/sellers/5.1/sidebar-content/1.tsx
+++ b/data/walkthroughs/scenarios/sellers/5.1/sidebar-content/1.tsx
@@ -1,0 +1,7 @@
+export const sidebarContentStage1 = (
+  <p>
+    This walkthrough examines bidding strategies for a landholder when they
+    have more than one option over the type of habitat change project they
+    might offer to the market.
+  </p>
+);

--- a/data/walkthroughs/scenarios/sellers/5.1/sidebar-content/12.tsx
+++ b/data/walkthroughs/scenarios/sellers/5.1/sidebar-content/12.tsx
@@ -1,0 +1,12 @@
+export const sidebarContentStage12 = (
+  <>
+    <p>
+      You were successful in securing funding for your woodland project!
+    </p>
+    <p>
+      As usual, the market mechanism allocates you a share of the surplus as a
+      bonus of £44,000. Since you offered at cost, this is effectively the
+      profit you will make from the woodland project.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/sellers/5.1/sidebar-content/2.tsx
+++ b/data/walkthroughs/scenarios/sellers/5.1/sidebar-content/2.tsx
@@ -1,0 +1,16 @@
+export const sidebarContentStage2 = (
+  <>
+    <p>
+      Let's imagine that you are such a landholder and the planned location of
+      your project is on the field shown on the map.
+    </p>
+    <p>
+      One option is to establish a woodland in your field.
+    </p>
+    <p>
+      That project has been assessed and will deliver 4 biodiversity credits and
+      1 water quality credits. To cover your costs the minimum you would need to
+      pursue that project would be £140,000.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/sellers/5.1/sidebar-content/3.tsx
+++ b/data/walkthroughs/scenarios/sellers/5.1/sidebar-content/3.tsx
@@ -1,0 +1,7 @@
+export const sidebarContentStage3 = (
+  <p>
+    Alternatively, you could create a wetland in that field. That project has
+    been assessed and will deliver 2 biodiversity credits and 5 water quality
+    credits and would cost you £180,000.
+  </p>
+);

--- a/data/walkthroughs/scenarios/sellers/5.1/sidebar-content/4.tsx
+++ b/data/walkthroughs/scenarios/sellers/5.1/sidebar-content/4.tsx
@@ -1,0 +1,26 @@
+export const sidebarContentStage4 = (
+  <>
+    <p>
+      The market into which you plan to enter an offer consists of 1 other
+      seller and 3 buyers who have entered the bids and offers shown here.
+    </p>
+    <p>
+      You have 3 options open to you;
+    </p>
+    <ul className="list-disc ml-5 space-y-5">
+      <li>
+          Offer up the woodland project
+      </li>
+      <li>
+        Offer up the wetland project
+      </li>
+      <li>
+        Offer both projects and let the market choose which (if either) should
+        be funded
+      </li>
+    </ul>
+    <p>
+      As we shall see, letting the market choose will always be your best choice.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/sellers/5.1/sidebar-content/5.tsx
+++ b/data/walkthroughs/scenarios/sellers/5.1/sidebar-content/5.tsx
@@ -1,0 +1,12 @@
+export const sidebarContentStage5 = (
+  <>
+    <p>
+      Imagine first that you decide to put in an offer for just the woodland
+      project.
+    </p>
+    <p>
+      Enter an offer at cost asking for a minimum payment of £140,000 for your
+      woodland project, then solve the market.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/sellers/5.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/5.2/index.ts
@@ -35,14 +35,14 @@ export const sellerScenario5_2: WalkthroughData = {
     {
       title: 'Buyer 2',
       cost: 120000,
-      accepted: true,
+      accepted: false,
       discountOrBonus: 0,
       products: { biodiversity: 3, nutrients: 0 }
     },
     {
       title: 'Buyer 3',
       cost: 100000,
-      accepted: false,
+      accepted: true,
       discountOrBonus: 40000,
       products: { biodiversity: 1, nutrients: 1 }
     }

--- a/data/walkthroughs/scenarios/sellers/5.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/5.2/index.ts
@@ -1,0 +1,91 @@
+import { sidebarContentStage1 } from "./sidebar-content/1";
+import { WalkthroughData } from "@/types/walkthrough";
+import { sidebarContentStage8 } from "./sidebar-content/8";
+
+export const sellerScenario5_2: WalkthroughData = {
+  myProjects: [
+    {
+      title: 'My Project',
+      subtitle: 'Project 1',
+      cost: 140000,
+      discountOrBonus: 0,
+      accepted: false,
+      isMyProject: true,
+      isInactive: true,
+      products: { biodiversity: 1, nutrients: 3 },
+    },
+    {
+      title: 'My Project',
+      subtitle: 'Project 2',
+      cost: 180000,
+      discountOrBonus: 50000,
+      accepted: true,
+      isMyProject: true,
+      products: { biodiversity: 2, nutrients: 5 },
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 220000,
+      accepted: true,
+      discountOrBonus: 50000,
+      products: { biodiversity: 1, nutrients: 4 }
+    },
+    {
+      title: 'Buyer 2',
+      cost: 120000,
+      accepted: true,
+      discountOrBonus: 0,
+      products: { biodiversity: 3, nutrients: 0 }
+    },
+    {
+      title: 'Buyer 3',
+      cost: 100000,
+      accepted: false,
+      discountOrBonus: 40000,
+      products: { biodiversity: 1, nutrients: 1 }
+    }
+  ],
+  sellerProjects: [
+    {
+      title: 'Seller 1',
+      cost: 90000,
+      accepted: false,
+      discountOrBonus: 0,
+      products: { biodiversity: 1, nutrients: 3 }
+    },
+  ],
+  sidebarContent: {
+    1: sidebarContentStage1,
+    8: sidebarContentStage8,
+  },
+  options: {
+    total_bids: '320,000',
+    total_offers: '180,000',
+    surplus: '140,000',
+    stages: 9,
+    set_my_price: 1,
+    allow_button_click: 1,
+    show_calculating_overlay: [3, 5, 7],
+    show_details_widget: 1,
+    show_solve_market: 2,
+    show_market_outcome: 4,
+    show_calculating_winners: 3,
+    show_distributing_surplus: 5,
+    show_calculating_final: 7,
+    show_surpluses: 6,
+    show_final_payments: 8,
+    show_balanced_market: 8,
+    show_bids: 1,
+    show_offers: 1,
+    show_maps: false,
+    show_full_map: 1,
+    show_highlighted_map: 2,
+    show_participants: 1,
+    hide_next_button: [1, 2, 3, 4, 5, 6, 7, 9],
+    hide_prev_button: [1],
+    show_losers: 4,
+    highlight_me: 2
+  }
+}

--- a/data/walkthroughs/scenarios/sellers/5.2/sidebar-content/1.tsx
+++ b/data/walkthroughs/scenarios/sellers/5.2/sidebar-content/1.tsx
@@ -1,0 +1,12 @@
+export const sidebarContentStage1 = (
+  <>
+    <p>
+      Now let's find out what would have happened if instead you had decided to
+      put in an offer for just the wetland project.
+    </p>
+    <p>
+      Enter an offer at your cost of £180,000 for the wetland project, then
+      solve the market.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/sellers/5.2/sidebar-content/8.tsx
+++ b/data/walkthroughs/scenarios/sellers/5.2/sidebar-content/8.tsx
@@ -1,0 +1,21 @@
+export const sidebarContentStage8 = (
+  <>
+    <p>
+      Again you successfully secure funding!
+    </p>
+    <p>
+      With the wetland project, however, your share of the surplus provides you
+      with a bonus of £50,000.
+    </p>
+    <p>
+      That's better than the £44,000 gained from the woodland project option.
+    </p>
+    <p>
+      Of course, when deciding how to offer you would not know whether the
+      wetland or the woodland project provides the best pay out.
+    </p>
+    <p>
+      So how can you choose which project to offer to the market?
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/sellers/5.3/index.ts
+++ b/data/walkthroughs/scenarios/sellers/5.3/index.ts
@@ -1,8 +1,9 @@
 import { sidebarContentStage1 } from "./sidebar-content/1";
 import { WalkthroughData } from "@/types/walkthrough";
 import { sidebarContentStage8 } from "./sidebar-content/8";
+import { sidebarContentStage9 } from "./sidebar-content/9";
 
-export const sellerScenario5_2: WalkthroughData = {
+export const sellerScenario5_3: WalkthroughData = {
   myProjects: [
     {
       title: 'My Project',
@@ -11,14 +12,13 @@ export const sellerScenario5_2: WalkthroughData = {
       discountOrBonus: 0,
       accepted: false,
       isMyProject: true,
-      isInactive: true,
       products: { biodiversity: 1, nutrients: 3 },
     },
     {
       title: 'My Project',
       subtitle: 'Project 2',
       cost: 180000,
-      discountOrBonus: 50000,
+      discountOrBonus: 73000,
       accepted: true,
       isMyProject: true,
       products: { biodiversity: 2, nutrients: 5 },
@@ -59,12 +59,13 @@ export const sellerScenario5_2: WalkthroughData = {
   sidebarContent: {
     1: sidebarContentStage1,
     8: sidebarContentStage8,
+    9: sidebarContentStage9,
   },
   options: {
     total_bids: '320,000',
     total_offers: '180,000',
     surplus: '140,000',
-    stages: 8,
+    stages: 9,
     set_my_price: 1,
     allow_button_click: 1,
     show_calculating_overlay: [3, 5, 7],
@@ -83,7 +84,7 @@ export const sellerScenario5_2: WalkthroughData = {
     show_full_map: 1,
     show_highlighted_map: 2,
     show_participants: 1,
-    hide_next_button: [1, 2, 3, 4, 5, 6, 7],
+    hide_next_button: [1, 2, 3, 4, 5, 6, 7, 9],
     hide_prev_button: [1],
     show_losers: 4,
     highlight_me: 2

--- a/data/walkthroughs/scenarios/sellers/5.3/sidebar-content/1.tsx
+++ b/data/walkthroughs/scenarios/sellers/5.3/sidebar-content/1.tsx
@@ -1,0 +1,18 @@
+export const sidebarContentStage1 = (
+  <>
+    <p>
+      Fortunately, the market allows you to enter both project options as an
+      'Either/Or' offer. The market will then choose the option that delivers
+      you the most surplus.
+    </p>
+    <p>
+      Try that now. Enter an offer at cost for the woodland project at £140,000
+      and an offer at cost for the wetland project at £180,000. Since those are
+      both projects on the same field, the market knows this is an Either/Or
+      offer.
+    </p>
+    <p>
+      Submit your Either/Or offer and then solve the market.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/sellers/5.3/sidebar-content/8.tsx
+++ b/data/walkthroughs/scenarios/sellers/5.3/sidebar-content/8.tsx
@@ -1,0 +1,17 @@
+export const sidebarContentStage8 = (
+  <>
+    <p>
+      As would be expected the market chose to fund your wetland project. What
+      is a little more surprising is that you have now been rewarded with an
+      even larger share of the surplus. As part of an Either/Or offer your
+      wetland project receives a bonus of £73,000 which is more than the £50,000
+      bonus it received when entered as a standalone project offer.
+    </p>
+    <p>
+      By providing two project options, your Either/Or offer opens up more
+      possibilities for the market to find surplus-generating trades. In that
+      way, your Either/Or bid contributes more to surplus generation and thus is
+      rewarded with a larger bonus.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/sellers/5.3/sidebar-content/9.tsx
+++ b/data/walkthroughs/scenarios/sellers/5.3/sidebar-content/9.tsx
@@ -1,0 +1,10 @@
+export const sidebarContentStage9 = (
+  <p>
+    When you have options over what sort of project to pursue, entering offers
+    for those options in an Either/Or offer will always be to your advantage.
+    The market likes offers that provide more options to generate
+    surplus-enhancing trades. As such an Either/Or offer will always be rewarded
+    with a larger bonus than would be garnered by one or other of those options
+    as a standalone project offer.
+  </p>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
   content: [
     "./pages/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}",
+    "./data/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
     extend: {

--- a/types/walkthrough.ts
+++ b/types/walkthrough.ts
@@ -41,6 +41,7 @@ export interface WalkthroughProject {
   cost: number;
   accepted: boolean | number,
   isMyProject?: boolean;
+  isInactive?: boolean;
   discountOrBonus: number;
   products: Products;
 }


### PR DESCRIPTION
This one includes adding support for multiple projects in the details box:

<img width="1708" alt="image" src="https://user-images.githubusercontent.com/5636273/202048522-fa1b66be-c9c8-4871-acd1-8020c201d292.png">

Designs:

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/5636273/202041339-6eb82c60-bc25-455e-a27a-bcaedb65d96e.png">

I now think that this is supposed to be the seller scenarios for walkthrough 5, not 4, so I'm adding it there for the time being. The titles match up that way at least, as this one is about selecting one or multiple projects. From the designs:

<img width="564" alt="image" src="https://user-images.githubusercontent.com/5636273/202041816-34ebb19f-f80f-47e2-8f60-bbdb3eabf71d.png">