### PR TITLE
feat: add return to walkthrough index screen

### DIFF
--- a/components/walkthroughs/Main/MainContent.tsx
+++ b/components/walkthroughs/Main/MainContent.tsx
@@ -1,20 +1,13 @@
 import { useEffect } from "react";
-import { motion } from "framer-motion";
 
-import { container, fadeInDown } from "@/utils/animations";
-import MarketOutcome from "./MarketOutcome";
 import LoadingOverlay from "./LoadingOverlay";
-import ParticipantsList from "./ParticipantsList";
 import { useWalkthroughContext } from "@/context/WalkthroughContext";
-import { WalkthroughMarketState, WalkthroughProject } from "@/types/walkthrough";
-import { RoleId } from "@/types/roles";
+import { WalkthroughMarketState } from "@/types/walkthrough";
+import MainContentBody from "./MainContentBody";
 
 const MainContent = () => {
   const {
-    stage,
-    scenario,
     isMarketSolving,
-    roleId,
     marketState,
     goToNextMarketState,
   } = useWalkthroughContext();
@@ -44,111 +37,10 @@ const MainContent = () => {
     goToNextMarketState,
   ]);
 
-  const activeUserProjects = scenario.myProjects.filter((project) => !project.isInactive);
-
-  const getAllProjects = (
-    projects: WalkthroughProject[],
-    projectRoleId: RoleId,
-  ) => {
-    if (projectRoleId === roleId) {
-      return [...projects, ...activeUserProjects];
-    }
-
-    return projects;
-  }
-
-  const getWinningProjects = (
-    projects: WalkthroughProject[],
-    projectRoleId: RoleId,
-  ) => (
-    getAllProjects(projects, projectRoleId).filter((project) => project.accepted)
-  );
-
-  const getLosingProjects = (
-    projects: WalkthroughProject[],
-    projectRoleId: RoleId,
-  ) => (
-    getAllProjects(projects, projectRoleId).filter((project) => !project.accepted)
-  );
-
-  const getActiveProjects = (
-    projects: WalkthroughProject[],
-    projectRoleId: RoleId,
-  ): WalkthroughProject[] => {
-    if (marketState < WalkthroughMarketState.solvable) {
-      return projects;
-    }
-
-    if (marketState >= WalkthroughMarketState.showing_winners) {
-      return getWinningProjects(projects, projectRoleId);
-    }
-
-    return getAllProjects(projects, projectRoleId);
-  };
-
   return (
     <div className="border-l border-green-dark pt-4 pb-24 w-full relative flex justify-center">
       <LoadingOverlay />
-
-      {stage >= scenario.options.show_participants && (
-        <>
-          {/* Losers list */}
-          {marketState >= WalkthroughMarketState.showing_winners && (
-            <motion.div
-              key="losing-participants"
-              variants={fadeInDown}
-              initial="hidden"
-              animate="visible"
-            >
-              <ParticipantsList
-                sellerProjects={getLosingProjects(scenario.sellerProjects, 'seller')}
-                buyerProjects={getLosingProjects(scenario.buyerProjects, 'buyer')}
-                type="losers"
-                stage={stage}
-                data={scenario}
-                roleId={roleId}
-              />
-            </motion.div>
-          )}
-
-          <div className="space-y-5">
-            <motion.div
-              key="all-participants"
-              variants={container}
-              initial="hidden"
-              animate="visible"
-              className="space-y-5"
-            >
-              <ParticipantsList
-                sellerProjects={getActiveProjects(scenario.sellerProjects, 'seller')}
-                buyerProjects={getActiveProjects(scenario.buyerProjects, 'buyer')}
-                stage={stage}
-                data={scenario}
-                roleId={roleId}
-              />
-            </motion.div>
-
-            {/* Market Outcome */}
-            {marketState >= WalkthroughMarketState.showing_winners && (
-              <motion.div
-                key="market-outcome"
-                variants={fadeInDown}
-                initial="hidden"
-                animate="visible"
-              >
-                <MarketOutcome
-                  sellerProjects={getWinningProjects(scenario.sellerProjects, 'seller')}
-                  buyerProjects={getWinningProjects(scenario.buyerProjects, 'buyer')}
-                />
-              </motion.div>
-            )}
-          </div>
-        </>
-      )}
-
-      {scenario.options.show_maps && stage < scenario.options.show_participants && (
-        <p className="text-4xl">MAP</p>
-      )}
+      <MainContentBody />
     </div>
   );
 };

--- a/components/walkthroughs/Main/MainContentBody.tsx
+++ b/components/walkthroughs/Main/MainContentBody.tsx
@@ -64,7 +64,7 @@ const MainContentBody = () => {
   if (stage === scenario.options.stages && !getNextScenarioId(scenarioId)) {
     return (
       <div className="flex items-center">
-        <Link href="/how-it-works">
+        <Link href={`/how-it-works#${roleId}`}>
           <a className="text-xl font-bold">Return to Walkthrough index</a>
         </Link>
       </div>

--- a/components/walkthroughs/Main/MainContentBody.tsx
+++ b/components/walkthroughs/Main/MainContentBody.tsx
@@ -6,11 +6,14 @@ import ParticipantsList from "./ParticipantsList";
 import { useWalkthroughContext } from "@/context/WalkthroughContext";
 import { WalkthroughMarketState, WalkthroughProject } from "@/types/walkthrough";
 import { RoleId } from "@/types/roles";
+import { getNextScenarioId } from "@/utils/walkthroughs";
+import Link from "next/link";
 
 const MainContentBody = () => {
   const {
     stage,
     scenario,
+    scenarioId,
     roleId,
     marketState,
   } = useWalkthroughContext();
@@ -56,6 +59,17 @@ const MainContentBody = () => {
 
     return getAllProjects(projects, projectRoleId);
   };
+
+  // Show the "return to index" link for the last stage of the last scenario.
+  if (stage === scenario.options.stages && !getNextScenarioId(scenarioId)) {
+    return (
+      <div className="flex items-center">
+        <Link href="/how-it-works">
+          <a className="text-xl font-bold">Return to Walkthrough index</a>
+        </Link>
+      </div>
+    )
+  }
 
   if (stage >= scenario.options.show_participants) {
     return (

--- a/components/walkthroughs/Main/MainContentBody.tsx
+++ b/components/walkthroughs/Main/MainContentBody.tsx
@@ -1,0 +1,127 @@
+import { motion } from "framer-motion";
+
+import { container, fadeInDown } from "@/utils/animations";
+import MarketOutcome from "./MarketOutcome";
+import ParticipantsList from "./ParticipantsList";
+import { useWalkthroughContext } from "@/context/WalkthroughContext";
+import { WalkthroughMarketState, WalkthroughProject } from "@/types/walkthrough";
+import { RoleId } from "@/types/roles";
+
+const MainContentBody = () => {
+  const {
+    stage,
+    scenario,
+    roleId,
+    marketState,
+  } = useWalkthroughContext();
+
+  const activeUserProjects = scenario.myProjects.filter((project) => !project.isInactive);
+
+  const getAllProjects = (
+    projects: WalkthroughProject[],
+    projectRoleId: RoleId,
+  ) => {
+    if (projectRoleId === roleId) {
+      return [...projects, ...activeUserProjects];
+    }
+
+    return projects;
+  }
+
+  const getWinningProjects = (
+    projects: WalkthroughProject[],
+    projectRoleId: RoleId,
+  ) => (
+    getAllProjects(projects, projectRoleId).filter((project) => project.accepted)
+  );
+
+  const getLosingProjects = (
+    projects: WalkthroughProject[],
+    projectRoleId: RoleId,
+  ) => (
+    getAllProjects(projects, projectRoleId).filter((project) => !project.accepted)
+  );
+
+  const getActiveProjects = (
+    projects: WalkthroughProject[],
+    projectRoleId: RoleId,
+  ): WalkthroughProject[] => {
+    if (marketState < WalkthroughMarketState.solvable) {
+      return projects;
+    }
+
+    if (marketState >= WalkthroughMarketState.showing_winners) {
+      return getWinningProjects(projects, projectRoleId);
+    }
+
+    return getAllProjects(projects, projectRoleId);
+  };
+
+  if (stage >= scenario.options.show_participants) {
+    return (
+      <>
+        {/* Losers list */}
+        {marketState >= WalkthroughMarketState.showing_winners && (
+          <motion.div
+            key="losing-participants"
+            variants={fadeInDown}
+            initial="hidden"
+            animate="visible"
+          >
+            <ParticipantsList
+              sellerProjects={getLosingProjects(scenario.sellerProjects, 'seller')}
+              buyerProjects={getLosingProjects(scenario.buyerProjects, 'buyer')}
+              type="losers"
+              stage={stage}
+              data={scenario}
+              roleId={roleId}
+            />
+          </motion.div>
+        )}
+
+        <div className="space-y-5">
+          <motion.div
+            key="all-participants"
+            variants={container}
+            initial="hidden"
+            animate="visible"
+            className="space-y-5"
+          >
+            <ParticipantsList
+              sellerProjects={getActiveProjects(scenario.sellerProjects, 'seller')}
+              buyerProjects={getActiveProjects(scenario.buyerProjects, 'buyer')}
+              stage={stage}
+              data={scenario}
+              roleId={roleId}
+            />
+          </motion.div>
+
+          {/* Market Outcome */}
+          {marketState >= WalkthroughMarketState.showing_winners && (
+            <motion.div
+              key="market-outcome"
+              variants={fadeInDown}
+              initial="hidden"
+              animate="visible"
+            >
+              <MarketOutcome
+                sellerProjects={getWinningProjects(scenario.sellerProjects, 'seller')}
+                buyerProjects={getWinningProjects(scenario.buyerProjects, 'buyer')}
+              />
+            </motion.div>
+          )}
+        </div>
+      </>
+    );
+  };
+
+  if (scenario.options.show_maps) {
+    return (
+      <p className="text-4xl">MAP</p>
+    );
+  }
+
+  return null;
+};
+
+export default MainContentBody;

--- a/pages/how-it-works/index.tsx
+++ b/pages/how-it-works/index.tsx
@@ -17,7 +17,11 @@ const HowItWorks: NextPage = () => (
       secondaryImageSrc={HeaderThumb}
     />
     {walkthroughsByRole.map(({ roleId, walkthroughs }) => (
-      <section key={roleId} className="mt-16">
+      <section
+        key={roleId}
+        className="mt-16"
+        id={roleId}
+      >
         <h2 className="heading-2 mx-6">{roles[roleId].label}</h2>
         <ul className="flex flex-wrap">
           {walkthroughs.map((walkthrough, walkthroughIndex) => (


### PR DESCRIPTION
Adds the "Return to walkthrough index" screen. The first commit https://github.com/curiousways/marketdesign/commit/e0ab0291e77125a2a51b4206e2fe9a8f4578a903 is just splitting out the body of the `MainContent` component. The second https://github.com/curiousways/marketdesign/commit/16f5ecff077264dbc64fa4a3431066695d9a7314 is actually adding the link.