### PR TITLE
feat: add buyer walkthrough 5

### DIFF
--- a/components/walkthroughs/Main/AdjustedProductCount.tsx
+++ b/components/walkthroughs/Main/AdjustedProductCount.tsx
@@ -1,4 +1,3 @@
-import { WalkthroughProject } from "@/types/walkthrough";
 import ProductCount from "./ProductCount";
 
 type Props = {

--- a/components/walkthroughs/Main/Project.tsx
+++ b/components/walkthroughs/Main/Project.tsx
@@ -70,9 +70,10 @@ const Project = ({
   const textColor = isBuyer ? 'text-brown' : 'text-green-light';
 
   const projectCost = getProjectCost(project);
+  const acceptedCost = accepted(projectCost);
 
   // Adjust metrics for projects that were only partially accepted.
-  const adjustedCost = getAdjustedCost(projectCost, accepted(projectCost));
+  const adjustedCost = getAdjustedCost(projectCost, acceptedCost);
 
   return (
     <motion.div
@@ -89,7 +90,7 @@ const Project = ({
       <div
         className={`absolute h-full ${backgroundColor} top-0 left-0`}
         style={{
-          width: typeof accepted === 'number' ? `${accepted}%` : '100%'
+          width: typeof acceptedCost === 'number' ? `${acceptedCost}%` : '100%'
         }}
       />
 
@@ -101,57 +102,62 @@ const Project = ({
       {/* Content */}
       <div className="z-10 items-center flex gap-x-10 justify-between w-full">
         <ProjectTitle
-          showAcceptedPercentage={showCosts}
+          acceptedCost={acceptedCost}
+          showCosts={showCosts}
           project={project}
         />
 
         {/* Products */}
         <div className="flex gap-x-10 flex-[20%]">
           {/* Biodiversity */}
-          <div
-            className={`h-[66px] w-[66px] rounded-lg flex items-center justify-center relative ${shadowColor}`}
-          >
-          <AdjustedProductCount
-              count={products.biodiversity}
-              accepted={accepted(projectCost)}
-            />
-            <svg
-              width="32"
-              height="32"
-              viewBox="0 0 32 32"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
+          {typeof products.biodiversity === 'number' && (
+            <div
+              className={`h-[66px] w-[66px] rounded-lg flex items-center justify-center relative ${shadowColor}`}
             >
-              <path
-                opacity="0.7"
-                d="M8.81169 7.68831C8.81169 3.71831 12.03 0.5 16 0.5C19.97 0.5 23.1884 3.71832 23.1884 7.68831C23.1884 8.30864 23.6912 8.81169 24.3116 8.81169C28.2817 8.81169 31.5 12.03 31.5 16C31.5 19.97 28.2817 23.1884 24.3116 23.1884C23.6913 23.1884 23.1884 23.6913 23.1884 24.3116C23.1884 28.2817 19.97 31.5 16 31.5C12.03 31.5 8.81169 28.2817 8.81169 24.3116C8.81169 23.6912 8.30864 23.1884 7.68831 23.1884C3.71832 23.1884 0.5 19.97 0.5 16C0.5 12.03 3.71831 8.81169 7.68831 8.81169C8.30873 8.81169 8.81169 8.30873 8.81169 7.68831Z"
-                stroke="white"
+              <AdjustedProductCount
+                count={products.biodiversity}
+                accepted={acceptedCost}
               />
-            </svg>
-          </div>
+              <svg
+                width="32"
+                height="32"
+                viewBox="0 0 32 32"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  opacity="0.7"
+                  d="M8.81169 7.68831C8.81169 3.71831 12.03 0.5 16 0.5C19.97 0.5 23.1884 3.71832 23.1884 7.68831C23.1884 8.30864 23.6912 8.81169 24.3116 8.81169C28.2817 8.81169 31.5 12.03 31.5 16C31.5 19.97 28.2817 23.1884 24.3116 23.1884C23.6913 23.1884 23.1884 23.6913 23.1884 24.3116C23.1884 28.2817 19.97 31.5 16 31.5C12.03 31.5 8.81169 28.2817 8.81169 24.3116C8.81169 23.6912 8.30864 23.1884 7.68831 23.1884C3.71832 23.1884 0.5 19.97 0.5 16C0.5 12.03 3.71831 8.81169 7.68831 8.81169C8.30873 8.81169 8.81169 8.30873 8.81169 7.68831Z"
+                  stroke="white"
+                />
+              </svg>
+            </div>
+          )}
 
           {/* Nutrients */}
-          <div
-            className={`h-[66px] w-[66px] ${shadowColor} rounded-lg flex items-center justify-center relative`}
-          >
-            <AdjustedProductCount
-              count={products.nutrients}
-              accepted={accepted(projectCost)}
-            />
-            <svg
-              width="22"
-              height="32"
-              viewBox="0 0 22 32"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
+          {typeof products.nutrients === 'number' && (
+            <div
+              className={`h-[66px] w-[66px] ${shadowColor} rounded-lg flex items-center justify-center relative`}
             >
-              <path
-                opacity="0.7"
-                d="M3.55382 28.7654L3.5538 28.7654C1.58991 27.0217 0.5 24.6703 0.5 22.2332C0.5 18.4038 2.4831 15.5249 5.04685 11.8362L5.05338 11.8268C6.98602 9.04625 9.20932 5.84757 10.9755 1.52781L10.9998 1.60143L11.0243 1.52726C12.7905 5.8473 15.0139 9.04614 16.9466 11.8268L16.9531 11.8361C19.5168 15.5249 21.5 18.4038 21.5 22.2332C21.5 24.6703 20.4101 27.0217 18.4462 28.7654C16.4949 30.498 13.7822 31.5 11 31.5C8.19741 31.5 5.51957 30.511 3.55382 28.7654Z"
-                stroke="white"
+              <AdjustedProductCount
+                count={products.nutrients}
+                accepted={acceptedCost}
               />
-            </svg>
-          </div>
+              <svg
+                width="22"
+                height="32"
+                viewBox="0 0 22 32"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  opacity="0.7"
+                  d="M3.55382 28.7654L3.5538 28.7654C1.58991 27.0217 0.5 24.6703 0.5 22.2332C0.5 18.4038 2.4831 15.5249 5.04685 11.8362L5.05338 11.8268C6.98602 9.04625 9.20932 5.84757 10.9755 1.52781L10.9998 1.60143L11.0243 1.52726C12.7905 5.8473 15.0139 9.04614 16.9466 11.8268L16.9531 11.8361C19.5168 15.5249 21.5 18.4038 21.5 22.2332C21.5 24.6703 20.4101 27.0217 18.4462 28.7654C16.4949 30.498 13.7822 31.5 11 31.5C8.19741 31.5 5.51957 30.511 3.55382 28.7654Z"
+                  stroke="white"
+                />
+              </svg>
+            </div>
+          )}
         </div>
 
         <div className="flex gap-x-10 flex-[50%]">

--- a/components/walkthroughs/Main/ProjectTitle.tsx
+++ b/components/walkthroughs/Main/ProjectTitle.tsx
@@ -17,8 +17,8 @@ export const ProjectTitle: FunctionComponent<Props> = ({
 }: Props) => {
   const { scenario } = useWalkthroughContext();
   const { title, subtitle, accepted } = project;
-  const acceptedPercentage = showCosts && Number.isFinite(showCosts)
-    ? accepted
+  const acceptedPercentage = showCosts && Number.isFinite(acceptedCost)
+    ? acceptedCost
     : null;
 
   return (

--- a/components/walkthroughs/Main/ProjectTitle.tsx
+++ b/components/walkthroughs/Main/ProjectTitle.tsx
@@ -6,16 +6,18 @@ import { FunctionComponent } from 'react';
 
 type Props = {
   project: WalkthroughProject;
-  showAcceptedPercentage?: boolean;
+  acceptedCost: number | boolean;
+  showCosts?: boolean;
 }
 
 export const ProjectTitle: FunctionComponent<Props> = ({
   project,
-  showAcceptedPercentage,
+  acceptedCost,
+  showCosts,
 }: Props) => {
   const { scenario } = useWalkthroughContext();
   const { title, subtitle, accepted } = project;
-  const acceptedPercentage = showAcceptedPercentage && Number.isFinite(accepted)
+  const acceptedPercentage = showCosts && Number.isFinite(showCosts)
     ? accepted
     : null;
 

--- a/components/walkthroughs/sidebar/Details.tsx
+++ b/components/walkthroughs/sidebar/Details.tsx
@@ -12,10 +12,15 @@ import { useWalkthroughContext } from "@/context/WalkthroughContext";
 import { WalkthroughMarketState, WalkthroughProject } from "@/types/walkthrough";
 import Input from "./Input";
 import { RoleId } from "@/types/roles";
+import ProductCount from "./ProductCount";
 
 const INPUT_NAME = 'project-cost';
 
 const getProjectValue = (project: WalkthroughProject, roleId: RoleId) => {
+  if (project.costPerCredit) {
+    return project.costPerCredit;
+  }
+
   if (!Array.isArray(project.cost)) {
     return project.cost;
   }
@@ -86,30 +91,28 @@ const Details = () => {
                 )}
                 <div className="flex gap-x-3 justify-between items-center">
                   {/* Vector */}
-                  <>{roleId === "seller" ? <SellerVector /> : <BuyerVector />}</>
+                  {!project.costPerCredit && (
+                    roleId === "seller" ? <SellerVector /> : <BuyerVector />
+                  )}
 
                   {/* Credits */}
                   <div className="flex gap-x-2">
-                    {/* Biodiversity */}
-                    <div className="relative">
-                      <span className="absolute -right-1 top-0 text-[10px] text-black font-bold border border-black rounded-full bg-white w-[14px] h-[14px] flex justify-center items-center">
-                        {project.products.biodiversity}
-                      </span>
-                      <BiodiversityIconGray />
-                    </div>
-                    {/* Nutrients */}
-                    <div className="relative">
-                      <span className="absolute -right-1 top-0 text-[10px] text-black font-bold border border-black rounded-full bg-white w-[14px] h-[14px] flex justify-center items-center">
-                      {project.products.nutrients}
-                      </span>
-                      <NutrientsIcon />
-                    </div>
+                    <ProductCount
+                      productCount={project.products.biodiversity}
+                      costPerCredit={project.costPerCredit}
+                      Icon={<BiodiversityIconGray />}
+                    />
+                    <ProductCount
+                      productCount={project.products.nutrients}
+                      costPerCredit={project.costPerCredit}
+                      Icon={<NutrientsIcon />}
+                    />
                   </div>
 
                   {/* Project Value */}
                   <p className="font-light">£{projectValue.toLocaleString()}</p>
 
-                  <div className="flex-1">
+                  <div className="flex-1 max-w-[50%]">
                     <Input
                       project={project}
                       populate={stage >= scenario.options.set_my_price && !project.isInactive}

--- a/components/walkthroughs/sidebar/Input.tsx
+++ b/components/walkthroughs/sidebar/Input.tsx
@@ -46,7 +46,7 @@ const Input: FunctionComponent<Props> = ({ project, populate, name }: Props) => 
       placeholder="Enter offer..."
       className="w-full text-sm inline-block rounded-lg py-2 px-3 bg-extra-light-grey"
       name={name}
-      defaultValue={populate ? project.cost : ''}
+      defaultValue={populate ? (project.costPerCredit ?? project.cost) : ''}
     />
   );
 };

--- a/components/walkthroughs/sidebar/ProductCount.tsx
+++ b/components/walkthroughs/sidebar/ProductCount.tsx
@@ -1,0 +1,33 @@
+import { classNames } from "@/utils/index";
+
+type Props = {
+  productCount?: number;
+  costPerCredit?: number;
+  Icon: JSX.Element;
+};
+
+const ProductCount = ({
+  productCount,
+  costPerCredit,
+  Icon,
+}: Props) => {
+  if (typeof productCount !== 'number') {
+    return null;
+  }
+
+  return (
+    <div className="relative flex">
+      {Icon}
+      <span
+        className={classNames(
+          'top-0 text-[10px] text-black border border-black rounded-full bg-white h-[14px] flex justify-center items-center',
+          costPerCredit ? 'p-1' : 'absolute font-bold w-[14px] -right-1',
+        )}
+      >
+        {costPerCredit ? `£${costPerCredit * productCount}` : productCount}
+      </span>
+    </div>
+  );
+};
+
+export default ProductCount;

--- a/data/walkthroughs/scenarios/buyers/5.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/5.1/index.ts
@@ -1,0 +1,79 @@
+import { sidebarContentStage1 } from "./sidebar-content/1";
+import { sidebarContentStage2 } from "./sidebar-content/2";
+import { sidebarContentStage3 } from "./sidebar-content/3";
+import { sidebarContentStage4 } from "./sidebar-content/4";
+import { WalkthroughScenario } from "@/types/walkthrough";
+import { sidebarContentStage10 } from "./sidebar-content/10";
+import { sidebarContentStage11 } from "./sidebar-content/11";
+
+export const buyerScenario5_1: WalkthroughScenario = {
+  myProjects: [
+    {
+      title: 'My Project',
+      subtitle: 'Biodiversity',
+      cost: 80000,
+      accepted: () => 75,
+      discountOrBonus: 17000,
+      products: { biodiversity: 4 },
+      costPerCredit: 20000,
+    },
+    {
+      title: 'My Project',
+      subtitle: 'Water Quality',
+      cost: 30000,
+      accepted: () => 50,
+      discountOrBonus: 5000,
+      products: { nutrients: 2 },
+      costPerCredit: 15000,
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 140000,
+      accepted: () => true,
+      discountOrBonus: 57000,
+      products: { biodiversity: 1, nutrients: 3 },
+    },
+  ],
+  sellerProjects: [
+    {
+      title: 'Seller 1',
+      cost: 50000,
+      accepted: () => true,
+      discountOrBonus: 4000,
+      products: { biodiversity: 3, nutrients: 0 },
+    },
+    {
+      title: 'Seller 2',
+      cost: 140000,
+      accepted: () => false,
+      discountOrBonus: 0,
+      products: { biodiversity: 4, nutrients: 4 },
+    },
+    {
+      title: 'Seller 3',
+      cost: 60000,
+      accepted: () => true,
+      discountOrBonus: 22000,
+      products: { biodiversity: 1, nutrients: 4 },
+    },
+  ],
+  sidebarContent: {
+    1: sidebarContentStage1,
+    2: sidebarContentStage2,
+    3: sidebarContentStage3,
+    4: sidebarContentStage4,
+    10: sidebarContentStage10,
+    11: sidebarContentStage11,
+  },
+  options: {
+    stages: 11,
+    set_my_price: 3,
+    allow_button_click: 3,
+    show_details_widget: 2,
+    show_costs: 3,
+    show_maps: true,
+    show_participants: 3,
+  },
+}

--- a/data/walkthroughs/scenarios/buyers/5.1/sidebar-content/1.tsx
+++ b/data/walkthroughs/scenarios/buyers/5.1/sidebar-content/1.tsx
@@ -1,0 +1,20 @@
+export const sidebarContentStage1 = (
+  <>
+    <p>
+      Not all buyers participate in the market because they have some particular
+      bundle of credits that they need to source. Examples, might be a company
+      purchasing credits to fulfil CSR commitments or an investor looking to buy
+      credits in the belief that they will be able to resell those credits at a
+      profit in the future.
+    </p>
+    <p>
+      In this walkthrough we consider how such an investor might enter a bid in
+      the market.
+    </p>
+    <p>
+      While there are a few ways this could be done, we focus on the situation
+      where an investor has a fixed investment budget and knows the most that
+      they are prepared to pay for credits.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/buyers/5.1/sidebar-content/10.tsx
+++ b/data/walkthroughs/scenarios/buyers/5.1/sidebar-content/10.tsx
@@ -1,0 +1,20 @@
+export const sidebarContentStage10 = (
+  <>
+    <p>
+      The market solves and your bid was partially successful. The market
+      managed to provide you with 3 of the 4 biodiversity credits you wanted
+      and 1 of the 2 water quality credits you wanted.
+    </p>
+    <p>
+      To understand better this market outcome, we have scaled down your bids to
+      show the maximum you were prepared to pay for those reduced quantities of
+      credits. Those amount to £60,000 and £15,000 or a total payment of
+      £75,000.
+    </p>
+    <p>
+      As always, you get your share of the surplus and receive a discount of
+      £22,000 meaning you only pay £53,000 for the bundle of credits that you
+      secured in the market.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/buyers/5.1/sidebar-content/11.tsx
+++ b/data/walkthroughs/scenarios/buyers/5.1/sidebar-content/11.tsx
@@ -1,0 +1,7 @@
+export const sidebarContentStage11 = (
+  <p>
+    The key lesson of this walkthrough is that the market can accept flexible
+    bids from buyers without some strict package of credits that they need to
+    acquire.
+  </p>
+);

--- a/data/walkthroughs/scenarios/buyers/5.1/sidebar-content/2.tsx
+++ b/data/walkthroughs/scenarios/buyers/5.1/sidebar-content/2.tsx
@@ -1,0 +1,14 @@
+export const sidebarContentStage2 = (
+  <>
+    <p>
+      To illustrate, let’s imagine you are a buyer seeking to purchase some
+      biodiversity credits and some water quality credits.
+    </p>
+    <p>
+      As shown above, your budget for biodiversity credits is £80,000 and you
+      are willing to pay up to £20,000 for each credit of that type. Likewise
+      you have set aside a budget of £30,000 to invest in water quality credits
+      and are willing to pay up to £15,000 per credit.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/buyers/5.1/sidebar-content/3.tsx
+++ b/data/walkthroughs/scenarios/buyers/5.1/sidebar-content/3.tsx
@@ -1,0 +1,13 @@
+export const sidebarContentStage3 = (
+  <>
+    <p>
+      The market in which you are trying to buy credits consists of 3 sellers
+      and 1 other buyer. Their bids and offers are shown here.
+    </p>
+    <p>
+      While you could ask for less for each credit type, let’s assume you bid at
+      value. Enter £20,000 as your bid per biodiversity credit and £15,000 as
+      your bid per water quality credit. Then submit your bid.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/buyers/5.1/sidebar-content/4.tsx
+++ b/data/walkthroughs/scenarios/buyers/5.1/sidebar-content/4.tsx
@@ -1,0 +1,19 @@
+export const sidebarContentStage4 = (
+  <>
+    <p>
+      Your investment project bid now appears in the market. Notice we have taken
+      your bid for each type of credit and worked out the number of credits you
+      could buy at that price within your budget. This is the demand for credits
+      that your bid implies.
+    </p>
+    <p>
+      Also notice we have made your bid divisible. As an investor, we assume
+      that if the market cannot provide you with your demand quantities you
+      would still be keen to acquire fewer credits so long as each costs you
+      less than your credit valuation.
+    </p>
+    <p>
+      Go ahead and solve the market.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/buyers/5.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/5.2/index.ts
@@ -1,0 +1,77 @@
+import { sidebarContentStage1 } from "./sidebar-content/1";
+import { sidebarContentStage2 } from "./sidebar-content/2";
+import { sidebarContentStage3 } from "./sidebar-content/3";
+import { WalkthroughScenario } from "@/types/walkthrough";
+import { sidebarContentStage11 } from "./sidebar-content/11";
+import { sidebarContentStage10 } from "./sidebar-content/10";
+
+export const buyerScenario5_2: WalkthroughScenario = {
+  myProjects: [
+    {
+      title: 'My Project',
+      subtitle: 'Biodiversity',
+      cost: 100000,
+      accepted: () => 50,
+      discountOrBonus: 10000,
+      products: { biodiversity: 4 },
+      costPerCredit: 25000,
+    },
+    {
+      title: 'My Project',
+      subtitle: 'Water Quality',
+      cost: 100000,
+      accepted: () => 40,
+      discountOrBonus: 6000,
+      products: { nutrients: 10 },
+      costPerCredit: 10000,
+    },
+  ],
+  buyerProjects: [
+    {
+      title: 'Buyer 1',
+      cost: 140000,
+      accepted: () => true,
+      discountOrBonus: 75000,
+      products: { biodiversity: 1, nutrients: 3 },
+    },
+  ],
+  sellerProjects: [
+    {
+      title: 'Seller 1',
+      cost: 60000,
+      accepted: () => true,
+      discountOrBonus: 13000,
+      products: { biodiversity: 2, nutrients: 3 },
+    },
+    {
+      title: 'Seller 2',
+      cost: 90000,
+      accepted: () => false,
+      discountOrBonus: 0,
+      products: { biodiversity: 2, nutrients: 3 },
+    },
+    {
+      title: 'Seller 3',
+      cost: 60000,
+      accepted: () => true,
+      discountOrBonus: 5000,
+      products: { biodiversity: 1, nutrients: 4 },
+    },
+  ],
+  sidebarContent: {
+    1: sidebarContentStage1,
+    2: sidebarContentStage2,
+    3: sidebarContentStage3,
+    10: sidebarContentStage10,
+    11: sidebarContentStage11,
+  },
+  options: {
+    stages: 11,
+    set_my_price: 3,
+    allow_button_click: 3,
+    show_details_widget: 2,
+    show_costs: 3,
+    show_maps: true,
+    show_participants: 3,
+  },
+}

--- a/data/walkthroughs/scenarios/buyers/5.2/sidebar-content/1.tsx
+++ b/data/walkthroughs/scenarios/buyers/5.2/sidebar-content/1.tsx
@@ -1,0 +1,21 @@
+export const sidebarContentStage1 = (
+  <>
+    <p>
+      In the previous walkthrough we imagined an investor that had separated
+      their investment budget up into different pots, one for each type of
+      credit.
+    </p>
+    <p>
+      Another way in which an investor might choose to bid in the market, is to
+      set just one budget for investment across all credit types. The market
+      would then select the quantities of each type of credit that the investor
+      should acquire within that budget in order to get the most surplus in
+      purchasing credits.
+    </p>
+    <p>
+      Roughly speaking, the mechanism makes that choice by observing the
+      investor’s valuation of each credit type and selecting credits of
+      whichever type are cheapest compared to that valuation.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/buyers/5.2/sidebar-content/10.tsx
+++ b/data/walkthroughs/scenarios/buyers/5.2/sidebar-content/10.tsx
@@ -1,0 +1,20 @@
+export const sidebarContentStage10 = (
+  <>
+    <p>
+      The market solves and your bid was successful. The market managed to
+      provide you with 2 of the 4 biodiversity credits you wanted and 4 of the
+      10 water quality credits you wanted.
+    </p>
+    <p>
+      In the market outcome, we have scaled down your bids to show the maximum
+      you were prepared to pay for those reduced quantities of credits. Those
+      amount to £50,000 and £40,000 or a total payment of £90,000, so within the
+      budget limit.
+    </p>
+    <p>
+      As always, you get your share of the surplus and receive a discount of
+      £16,000 meaning you only pay £74,000 for the bundle of credits that you
+      secured in the market.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/buyers/5.2/sidebar-content/11.tsx
+++ b/data/walkthroughs/scenarios/buyers/5.2/sidebar-content/11.tsx
@@ -1,0 +1,7 @@
+export const sidebarContentStage11 = (
+  <p>
+    The key lesson of this walkthrough is that investors can let the market
+    decide how best to use a fixed investment budget with regards to choosing
+    the quantities of different credits to purchase.
+  </p>
+);

--- a/data/walkthroughs/scenarios/buyers/5.2/sidebar-content/2.tsx
+++ b/data/walkthroughs/scenarios/buyers/5.2/sidebar-content/2.tsx
@@ -1,0 +1,13 @@
+export const sidebarContentStage2 = (
+  <>
+    <p>
+      To illustrate, let’s imagine you are a buyer seeking to purchase some
+      biodiversity credits and some water quality credits.
+    </p>
+    <p>
+      As shown above, your budget for those purchases is £100,000 and you are
+      willing to pay up to £25,000 for each biodiversity credit and up to
+      £10,000 for each water quality credit.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/buyers/5.2/sidebar-content/3.tsx
+++ b/data/walkthroughs/scenarios/buyers/5.2/sidebar-content/3.tsx
@@ -1,0 +1,13 @@
+export const sidebarContentStage3 = (
+  <>
+    <p>
+      The market in which you are trying to buy credits consists of 3 sellers
+      and 1 other buyer. Their bids and offers are shown here.
+    </p>
+    <p>
+      While you could ask for less for each credit type, let’s assume you bid at
+      value. Enter £25,000 as your bid per biodiversity credit and £10,000 as
+      your bid per water quality credit. Then submit your bid.
+    </p>
+  </>
+);

--- a/data/walkthroughs/scenarios/buyers/index.ts
+++ b/data/walkthroughs/scenarios/buyers/index.ts
@@ -10,6 +10,8 @@ import { buyerScenario3_1 } from "./3.1";
 import { buyerScenario3_2 } from "./3.2";
 import { buyerScenario4_1 } from "./4.1";
 import { buyerScenario4_2 } from "./4.2";
+import { buyerScenario5_1 } from "./5.1";
+import { buyerScenario5_2 } from "./5.2";
 
 export const buyerWalkthroughs: Walkthrough[] = [
   {
@@ -41,6 +43,13 @@ export const buyerWalkthroughs: Walkthrough[] = [
     scenarios: [
       buyerScenario4_1,
       buyerScenario4_2,
+    ],
+  },
+  {
+    title: 'Investor Bidding',
+    scenarios: [
+      buyerScenario5_1,
+      buyerScenario5_2,
     ],
   },
 ];

--- a/types/walkthrough.ts
+++ b/types/walkthrough.ts
@@ -13,8 +13,8 @@ export interface WalkthroughOptions {
 };
 
 export interface Products {
-  biodiversity: number;
-  nutrients: number;
+  biodiversity?: number;
+  nutrients?: number;
 }
 
 export interface WalkthroughProject {
@@ -25,6 +25,7 @@ export interface WalkthroughProject {
   isInactive?: boolean;
   discountOrBonus: number;
   products: Products;
+  costPerCredit?: number;
 }
 
 export interface WalkthroughScenario {


### PR DESCRIPTION
Adds the scenario with the credit bidding stuff:

<img width="1696" alt="image" src="https://user-images.githubusercontent.com/5636273/202462255-f40fba55-471d-46cd-913b-1a2a8cf47a2c.png">

UI-wise it is slightly different from the designs, where we have this kind of dotted line between both of "my projects":

<img width="633" alt="image" src="https://user-images.githubusercontent.com/5636273/202462708-0424b36f-f0b3-4c6c-b9c9-2f7e0028b56e.png">

That would be a bit of a pain to do at the moment so thinking it kind of works like this. The UI could be tweaked later if that bit feels important!