### PR TITLE
feat: add more animations when calculating market

### DIFF
--- a/components/walkthroughs/Main/MainContent.tsx
+++ b/components/walkthroughs/Main/MainContent.tsx
@@ -1,11 +1,9 @@
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
 
 import LoadingOverlay from "./LoadingOverlay";
 import { useWalkthroughContext } from "@/context/WalkthroughContext";
 import { WalkthroughMarketState } from "@/types/walkthrough";
 import MainContentBody from "./MainContentBody";
-import { WalkthroughBackgroundRight } from "../icons/WalkthroughBackground";
-import { WalkthroughBackgroundLeft } from "../icons/WalkthroughBackgroundLeft";
 import Background from "./Background";
 
 const MARKET_SOLVING_TIMEOUT = 4000;
@@ -82,7 +80,7 @@ const MainContent = () => {
   ]);
 
   return (
-    <div className="border-l border-green-dark pt-4 w-full relative flex justify-center">
+    <div className="border-l border-green-dark pt-8 w-full relative flex justify-center">
       <div className="z-20">
         <LoadingOverlay />
       </div>

--- a/components/walkthroughs/Main/MainContentBody.tsx
+++ b/components/walkthroughs/Main/MainContentBody.tsx
@@ -73,17 +73,13 @@ const MainContentBody = () => {
       return projects;
     }
 
-    if (marketState >= WalkthroughMarketState.showing_winners) {
-      return getWinningProjects(projects, projectRoleId);
-    }
-
     return getAllProjects(projects, projectRoleId);
   };
 
   // Show the "return to index" link for the last stage of the last scenario.
   if (stage === scenario.options.stages && !getNextScenarioId(scenarioId)) {
     return (
-      <div className="flex items-center">
+      <div className="flex items-center h-full">
         <Link href={`/how-it-works#${roleId}`}>
           <a className="text-xl font-bold">Return to Walkthrough index</a>
         </Link>
@@ -94,57 +90,35 @@ const MainContentBody = () => {
   if (scenario.options.showParticipants) {
     return (
       <>
-        {/* Losers list */}
+        <motion.div
+          key="losing-participants"
+          variants={fadeInDown}
+          initial="hidden"
+          animate="visible"
+        >
+          <ParticipantsList
+            sellerProjects={getActiveProjects(scenario.sellerProjects, 'seller')}
+            buyerProjects={getActiveProjects(scenario.buyerProjects, 'buyer')}
+            losingSellerProjects={getLosingProjects(scenario.sellerProjects, 'seller')}
+            losingBuyerProjects={getLosingProjects(scenario.buyerProjects, 'buyer')}
+            data={scenario}
+            roleId={roleId}
+          />
+        </motion.div>
+
         {marketState >= WalkthroughMarketState.showing_winners && (
           <motion.div
-            key="losing-participants"
+            key="market-outcome"
             variants={fadeInDown}
             initial="hidden"
             animate="visible"
           >
-            <ParticipantsList
-              sellerProjects={getLosingProjects(scenario.sellerProjects, 'seller')}
-              buyerProjects={getLosingProjects(scenario.buyerProjects, 'buyer')}
-              type="losers"
-              stage={stage}
-              data={scenario}
-              roleId={roleId}
+            <MarketOutcome
+              sellerProjects={getWinningProjects(scenario.sellerProjects, 'seller')}
+              buyerProjects={getWinningProjects(scenario.buyerProjects, 'buyer')}
             />
           </motion.div>
         )}
-
-        <div className="space-y-5">
-          <motion.div
-            key="all-participants"
-            variants={container}
-            initial="hidden"
-            animate="visible"
-            className="space-y-5"
-          >
-            <ParticipantsList
-              sellerProjects={getActiveProjects(scenario.sellerProjects, 'seller')}
-              buyerProjects={getActiveProjects(scenario.buyerProjects, 'buyer')}
-              stage={stage}
-              data={scenario}
-              roleId={roleId}
-            />
-          </motion.div>
-
-          {/* Market Outcome */}
-          {marketState >= WalkthroughMarketState.showing_winners && (
-            <motion.div
-              key="market-outcome"
-              variants={fadeInDown}
-              initial="hidden"
-              animate="visible"
-            >
-              <MarketOutcome
-                sellerProjects={getWinningProjects(scenario.sellerProjects, 'seller')}
-                buyerProjects={getWinningProjects(scenario.buyerProjects, 'buyer')}
-              />
-            </motion.div>
-          )}
-        </div>
       </>
     );
   };

--- a/components/walkthroughs/Main/ParticipantsList.tsx
+++ b/components/walkthroughs/Main/ParticipantsList.tsx
@@ -1,18 +1,15 @@
-import BuyerLost from "./BuyerLost";
-import SellerLost from "./SellerLost";
-
-import { WalkthroughScenario, WalkthroughProject} from "@/types/walkthrough";
+import { WalkthroughScenario, WalkthroughProject, WalkthroughMarketState} from "@/types/walkthrough";
 import { RoleId } from "@/types/roles";
 import Project from "./Project";
 import { useWalkthroughContext } from "@/context/WalkthroughContext";
-import { isMyProject } from "@/utils/walkthroughs";
+import { findProjectIndex, includesProject, isMyProject } from "@/utils/walkthroughs";
 
 type Props = {
   buyerProjects: WalkthroughProject[];
   sellerProjects: WalkthroughProject[];
-  stage: number;
+  losingBuyerProjects: WalkthroughProject[];
+  losingSellerProjects: WalkthroughProject[];
   data: WalkthroughScenario;
-  type?: "winners" | "losers";
   roleId: RoleId;
 };
 
@@ -21,83 +18,59 @@ type Props = {
  */
 const sortMyProjects = (
   scenario: WalkthroughScenario,
-  allProjects: WalkthroughProject[],
-) => (
-  allProjects.sort((a, b) => (
-    Number(isMyProject(scenario, b) ?? 0) - Number(isMyProject(scenario, a) ?? 0)
-  ))
-);
+  buyerProjects: WalkthroughProject[],
+  sellerProjects: WalkthroughProject[],
+  losingProjects: WalkthroughProject[],
+  showingWinners: boolean,
+) => [...sellerProjects, ...buyerProjects].sort((a, b) => {
+  const isLoserA = showingWinners && includesProject(a, losingProjects);
+  const isLoserB = showingWinners && includesProject(b, losingProjects);
+  const isMyProjectA = isMyProject(scenario, a);
+  const isMyProjectB = isMyProject(scenario, b);
+
+  return (
+    Number(isLoserB ?? 0)
+    - Number(isLoserA ?? 0)
+  ) || (
+    Number(isMyProjectB ?? 0)
+    - Number(isMyProjectA ?? 0)
+  );
+});
 
 const ParticipantsList = ({
   buyerProjects,
   sellerProjects,
-  stage,
+  losingBuyerProjects,
+  losingSellerProjects,
   data,
   roleId,
-  type = "winners",
 }: Props) => {
-  const { scenario } = useWalkthroughContext();
-  const sortedBuyerProjects = sortMyProjects(scenario, buyerProjects);
-  const sortedSellerProjects = sortMyProjects(scenario, sellerProjects);
+  const { scenario, marketState } = useWalkthroughContext();
+  const showingWinners = marketState >= WalkthroughMarketState.showing_winners;
+  const allLosingProjects = [...losingSellerProjects, ...losingBuyerProjects];
+  const sortedProjects = sortMyProjects(
+    scenario,
+    buyerProjects,
+    sellerProjects,
+    allLosingProjects,
+    showingWinners,
+  );
 
   return (
-    <div className="z-10 space-y-5">
-      {type === "winners" && (
-        <>
-          {/* Sellers */}
-          {sortedSellerProjects.map((project) => (
-            <Project
-              key={project.title + project.subtitle}
-              projectRoleId="seller"
-              stage={stage}
-              project={project}
-              options={data.options}
-              roleId={roleId}
-            />
-          ))}
-
-          {/* Buyers */}
-          {sortedBuyerProjects.map((project) => (
-            <Project
-            key={project.title + project.subtitle}
-              projectRoleId="buyer"
-              stage={stage}
-              project={project}
-              options={data.options}
-              roleId={roleId}
-            />
-          ))}
-        </>
-      )}
-
-      {type === "losers" && (
-        <div className="px-2">
-          {/* Sellers */}
-          {sortedSellerProjects.map((project) => (
-            <div
-            key={project.title + project.subtitle}
-              className="mb-2"
-            >
-              <SellerLost
-                project={project}
-              />
-            </div>
-          ))}
-
-          {/* Buyers */}
-          {sortedBuyerProjects.map((project) => (
-            <div
-              key={project.title + project.subtitle}
-              className="mb-2"
-            >
-              <BuyerLost
-                project={project}
-              />
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
+    <ul>
+      {sortedProjects.map((project) => (
+        <li key={project.title + project.subtitle}>
+          <Project
+            projectRoleId={includesProject(project, buyerProjects) ? 'buyer' : 'seller'}
+            project={project}
+            options={data.options}
+            roleId={roleId}
+            isLoser={includesProject(project, allLosingProjects)}
+            loserIndex={findProjectIndex(project, allLosingProjects)}
+          />
+        </li>
+      ))}
+    </ul>
   );
 };
 

--- a/components/walkthroughs/Main/ParticipantsList.tsx
+++ b/components/walkthroughs/Main/ParticipantsList.tsx
@@ -37,6 +37,32 @@ const sortMyProjects = (
   );
 });
 
+const getMyActiveProjects = (
+  projects: WalkthroughProject[],
+  scenario: WalkthroughScenario,
+) => scenario.myProjects.filter((project) => projects.includes(project));
+
+const getIsMyFirstProject = (
+  projects: WalkthroughProject[],
+  project: WalkthroughProject,
+  scenario: WalkthroughScenario,
+) => {
+  const projectIndex = getMyActiveProjects(projects, scenario).indexOf(project);
+
+  return projectIndex === 0;
+};
+
+const getIsMyLastProject = (
+  projects: WalkthroughProject[],
+  project: WalkthroughProject,
+  scenario: WalkthroughScenario,
+) => {
+  const activeProjects = getMyActiveProjects(projects, scenario);
+  const projectIndex = getMyActiveProjects(projects, scenario).indexOf(project);
+
+  return projectIndex + 1 === activeProjects.length;
+};
+
 const ParticipantsList = ({
   buyerProjects,
   sellerProjects,
@@ -58,18 +84,29 @@ const ParticipantsList = ({
 
   return (
     <ul>
-      {sortedProjects.map((project) => (
-        <li key={project.title + project.subtitle}>
-          <Project
-            projectRoleId={includesProject(project, buyerProjects) ? 'buyer' : 'seller'}
-            project={project}
-            options={data.options}
-            roleId={roleId}
-            isLoser={includesProject(project, allLosingProjects)}
-            loserIndex={findProjectIndex(project, allLosingProjects)}
-          />
-        </li>
-      ))}
+      {sortedProjects.map((project) => {
+        const isMyFirstProject = getIsMyFirstProject(sortedProjects, project, scenario);
+        const isMyLastProject = getIsMyLastProject(sortedProjects, project, scenario);
+
+        return (
+          <li key={project.title + project.subtitle}>
+            <Project
+              projectRoleId={includesProject(project, buyerProjects) ? 'buyer' : 'seller'}
+              project={project}
+              options={data.options}
+              roleId={roleId}
+              isLoser={includesProject(project, allLosingProjects)}
+              loserIndex={findProjectIndex(project, allLosingProjects)}
+              isMyFirstProject={isMyFirstProject}
+              isMyLastProject={isMyLastProject}
+              isMySubsequentProject={(
+                getMyActiveProjects(sortedProjects, scenario).includes(project) &&
+                !isMyFirstProject
+              )}
+            />
+          </li>
+        );
+      })}
     </ul>
   );
 };

--- a/components/walkthroughs/Main/Project.tsx
+++ b/components/walkthroughs/Main/Project.tsx
@@ -207,6 +207,7 @@ const useProjectAnimation = (
 
     if (!showLoserStyles) {
       setAnimation({
+        padding: '1.25rem',
         height: PROJECT_HEIGHT,
         width: PROJECT_WIDTH,
         transform: defaultTransform,
@@ -217,6 +218,7 @@ const useProjectAnimation = (
     }
 
     const styles = {
+      padding: '.25rem',
       height: [
         PROJECT_HEIGHT,
         PROJECT_HEIGHT,
@@ -323,7 +325,7 @@ const Project = ({
           animate={projectAnimation}
           style={getMyProjectStyles(project, scenario)}
           className={classNames(
-            "absolute p-5 flex overflow-hidden left-0 top-0",
+            "absolute flex overflow-hidden left-0 top-0",
             className,
           )}
         >
@@ -345,7 +347,7 @@ const Project = ({
           {/* Content */}
           <div className={classNames(
             "z-10 items-center flex justify-between w-full",
-            showLoserStyles ? 'gap-x-4' : 'gap-x-10',
+            showLoserStyles ? 'gap-x-2' : 'gap-x-10',
           )}>
             <ProjectTitle
               acceptedCost={acceptedCost}

--- a/components/walkthroughs/Main/Project.tsx
+++ b/components/walkthroughs/Main/Project.tsx
@@ -32,6 +32,9 @@ type Props = {
   isLoser: boolean;
   loserIndex?: number;
   className?: string;
+  isMyFirstProject: boolean;
+  isMyLastProject: boolean;
+  isMySubsequentProject: boolean;
 };
 
 const getAdjustedCost = (
@@ -54,27 +57,11 @@ const calculatePayment = (
   return adjustedCost + discountOrBonus;
 }
 
-const isMyFirstProject = (
-  project: WalkthroughProject,
-  scenario: WalkthroughScenario,
-) => {
-  const projectIndex = scenario.myProjects.indexOf(project);
-
-  return projectIndex === 0;
-}
-
-const isMyLastProject = (
-  project: WalkthroughProject,
-  scenario: WalkthroughScenario,
-) => {
-  const projectIndex = scenario.myProjects.indexOf(project);
-
-  return projectIndex + 1 === scenario.myProjects.length;
-}
-
 const getMyProjectStyles = (
   project: WalkthroughProject,
   scenario: WalkthroughScenario,
+  isMyFirstProject: boolean,
+  isMyLastProject: boolean,
 ): CSSProperties => {
   const borderRadius = '0.5rem';
   const borderWidth = '2px';
@@ -94,10 +81,7 @@ const getMyProjectStyles = (
     borderLeftWidth: borderWidth,
   };
 
-  const isFirst = isMyFirstProject(project, scenario);
-  const isLast = isMyLastProject(project, scenario);
-
-  if (isFirst) {
+  if (isMyFirstProject) {
     Object.assign(myProjectStyles, {
       borderTopColor: borderColor,
       borderTopStyle: borderStyle,
@@ -107,7 +91,7 @@ const getMyProjectStyles = (
     });
   }
 
-  if (isLast) {
+  if (isMyLastProject) {
     Object.assign(myProjectStyles, {
       borderBottomColor: borderColor,
       borderBottomStyle: borderStyle,
@@ -116,7 +100,7 @@ const getMyProjectStyles = (
       borderBottomRightRadius: borderRadius,
     });
 
-    if (!isFirst) {
+    if (!isMyFirstProject) {
       Object.assign(myProjectStyles, {
         marginTop: 0,
       });
@@ -265,6 +249,9 @@ const Project = ({
   isLoser,
   loserIndex,
   className = "",
+  isMyFirstProject,
+  isMyLastProject,
+  isMySubsequentProject,
 }: Props) => {
   const { marketState, scenario, getProjectCost } = useWalkthroughContext();
   const { discountOrBonus, products, accepted } = project;
@@ -277,11 +264,6 @@ const Project = ({
   const showingWinners = marketState >= WalkthroughMarketState.showing_winners;
   const showLoserStyles = isLoser && showingWinners;
   const isNotAccepted = showingWinners && !acceptedCost;
-
-  const isMySubsequentProject = (
-    isMyProject(scenario, project) &&
-    !isMyFirstProject(project, scenario)
-  );
 
   const rowAnimation = useRowAnimation(
     showLoserStyles,
@@ -323,7 +305,12 @@ const Project = ({
       >
         <motion.div
           animate={projectAnimation}
-          style={getMyProjectStyles(project, scenario)}
+          style={getMyProjectStyles(
+            project,
+            scenario,
+            isMyFirstProject,
+            isMyLastProject,
+          )}
           className={classNames(
             "absolute flex overflow-hidden left-0 top-0",
             className,

--- a/components/walkthroughs/Main/Project.tsx
+++ b/components/walkthroughs/Main/Project.tsx
@@ -1,4 +1,4 @@
-import { motion } from "framer-motion";
+import { AnimationProps, motion } from "framer-motion";
 
 import { classNames } from "@/utils/index";
 
@@ -9,18 +9,27 @@ import HammerIcon from "../icons/HammerIcon";
 import PoundcashTag from "../icons/PoundcashTag";
 import { RoleId } from "@/types/roles";
 import { ProjectTitle } from "./ProjectTitle";
-import AdjustedProductCount from "./AdjustedProductCount";
 import CartPlus from "../icons/CartPlus";
 import { useWalkthroughContext } from "@/context/WalkthroughContext";
 import { isMyProject } from "@/utils/walkthroughs";
-import { CSSProperties } from "react";
+import { CSSProperties, useEffect, useState } from "react";
+import ProjectBiodiversity from "./ProjectBiodiversity";
+import ProjectNutrients from "./ProjectNutrients";
+
+const PROJECT_HEIGHT = 120;
+const PROJECT_WIDTH = 800;
+const PROJECT_BOTTOM_MARGIN = 15;
+const COLLAPSED_PROJECT_HEIGHT = 60;
+const COLLAPSED_PROJECT_WIDTH = 250;
+const SHOW_LOSERS_MAX_SCREEN_WIDTH = 1800;
 
 type Props = {
   project: WalkthroughProject;
   projectRoleId: 'buyer' | 'seller';
-  stage: number;
   options: WalkthroughOptions;
   roleId: RoleId;
+  isLoser: boolean;
+  loserIndex?: number;
   className?: string;
 };
 
@@ -116,22 +125,171 @@ const getMyProjectStyles = (
   return myProjectStyles;
 };
 
+const useRowAnimation = (
+  showLoserStyles: boolean,
+  isMySubsequentProject: boolean,
+  fade: boolean,
+) => {
+  const [animation, setAnimation] = useState<AnimationProps['animate']>();
+
+  useEffect(() => {
+    const commonStyles: AnimationProps['animate'] = {
+      opacity: fade ? .5 : 1,
+      width: PROJECT_WIDTH,
+    };
+
+    const marginTop = isMySubsequentProject ? -PROJECT_BOTTOM_MARGIN : 0;
+
+    if (!showLoserStyles) {
+      setAnimation({
+        height: PROJECT_HEIGHT,
+        marginBottom: PROJECT_BOTTOM_MARGIN,
+        marginTop,
+        ...commonStyles,
+      });
+
+      return;
+    }
+
+    setAnimation({
+      height: [
+        PROJECT_HEIGHT,
+        PROJECT_HEIGHT,
+        PROJECT_HEIGHT,
+        PROJECT_HEIGHT,
+        PROJECT_HEIGHT,
+        PROJECT_HEIGHT,
+        0,
+        0,
+      ],
+      marginBottom: [
+        PROJECT_BOTTOM_MARGIN,
+        PROJECT_BOTTOM_MARGIN,
+        PROJECT_BOTTOM_MARGIN,
+        PROJECT_BOTTOM_MARGIN,
+        PROJECT_BOTTOM_MARGIN,
+        PROJECT_BOTTOM_MARGIN,
+        0,
+        0,
+      ],
+      ...commonStyles,
+    });
+  }, [showLoserStyles, isMySubsequentProject, fade]);
+
+  return animation;
+};
+
+const useProjectAnimation = (
+  showLoserStyles: boolean,
+  loserIndex: number = 0,
+) => {
+  const [animation, setAnimation] = useState<AnimationProps['animate']>();
+
+  useEffect(() => {
+    const commonStyles: AnimationProps['animate'] = {
+      opacity: 1,
+    };
+
+    const spacing = 10;
+    const defaultTransform = 'translate3d(0px, 0px, 0px)';
+    const collapsedTransformX = `-${COLLAPSED_PROJECT_WIDTH + spacing}px`;
+    const collapsedTransformY = `${(
+      (loserIndex * COLLAPSED_PROJECT_HEIGHT) + (loserIndex ? loserIndex * spacing : 0)
+    )}px`;
+
+    const collapsedTransform1 = `translate3d(0px, ${collapsedTransformY}, 0px)`;
+    const collapsedTransform2 = `translate3d(${[
+      collapsedTransformX,
+      collapsedTransformY,
+      '0px',
+    ].join(', ')})`;
+
+    if (!showLoserStyles) {
+      setAnimation({
+        height: PROJECT_HEIGHT,
+        width: PROJECT_WIDTH,
+        transform: defaultTransform,
+        ...commonStyles,
+      });
+
+      return;
+    }
+
+    const styles = {
+      height: [
+        PROJECT_HEIGHT,
+        PROJECT_HEIGHT,
+        COLLAPSED_PROJECT_HEIGHT,
+        COLLAPSED_PROJECT_HEIGHT,
+        COLLAPSED_PROJECT_HEIGHT,
+        COLLAPSED_PROJECT_HEIGHT,
+        COLLAPSED_PROJECT_HEIGHT,
+      ],
+      width: [
+        PROJECT_WIDTH,
+        PROJECT_WIDTH,
+        COLLAPSED_PROJECT_WIDTH,
+        COLLAPSED_PROJECT_WIDTH,
+        COLLAPSED_PROJECT_WIDTH,
+        COLLAPSED_PROJECT_WIDTH,
+        COLLAPSED_PROJECT_WIDTH,
+      ],
+      ...commonStyles,
+    };
+
+    if (window.innerWidth >= SHOW_LOSERS_MAX_SCREEN_WIDTH) {
+      styles.transform = [
+        defaultTransform,
+        defaultTransform,
+        collapsedTransform1,
+        collapsedTransform1,
+        collapsedTransform1,
+        collapsedTransform2,
+        collapsedTransform2,
+      ];
+    };
+
+    setAnimation(styles);
+  }, [showLoserStyles, loserIndex]);
+
+  return animation;
+};
+
 const Project = ({
   project,
   projectRoleId,
-  stage,
   options,
+  isLoser,
+  loserIndex,
   className = "",
 }: Props) => {
   const { marketState, scenario, getProjectCost } = useWalkthroughContext();
   const { discountOrBonus, products, accepted } = project;
   const { showCosts } = options;
 
-  const showAcceptedState = marketState >= WalkthroughMarketState.showing_winners;
   const projectCost = getProjectCost(project);
   const acceptedCost = accepted(projectCost);
-  const isNotAccepted = showAcceptedState && !acceptedCost;
   const isBuyer = projectRoleId === 'buyer';
+
+  const showingWinners = marketState >= WalkthroughMarketState.showing_winners;
+  const showLoserStyles = isLoser && showingWinners;
+  const isNotAccepted = showingWinners && !acceptedCost;
+
+  const isMySubsequentProject = (
+    isMyProject(scenario, project) &&
+    !isMyFirstProject(project, scenario)
+  );
+
+  const rowAnimation = useRowAnimation(
+    showLoserStyles,
+    isMySubsequentProject,
+    isNotAccepted,
+  );
+
+  const projectAnimation = useProjectAnimation(
+    showLoserStyles,
+    loserIndex,
+  );
 
   // Define some colour classes.
   const shadowColor = isBuyer ? 'neo-shadow-brown' : 'neo-shadow-green';
@@ -142,182 +300,166 @@ const Project = ({
   // Adjust metrics for projects that were only partially accepted.
   const adjustedCost = getAdjustedCost(projectCost, acceptedCost);
 
-  const isMySubsequentProject = (
-    isMyProject(scenario, project) &&
-    !isMyFirstProject(project, scenario)
-  );
-
   return (
     <motion.div
       variants={fadeInDown}
       initial="hidden"
-      animate="visible"
-      style={getMyProjectStyles(project, scenario)}
+      animate={rowAnimation}
+      style={{ overflow: 'visible' }}
       className="overflow-hidden"
     >
       {/* Add a divider between multiple user projects. */}
       {isMySubsequentProject && (
-        <div className={`border-t-2 border-dashed ${dividerColor} w-full`} />
+        <div className="border-black border-l-2 border-r-2 relative h-[2px] z-10 bg-white">
+          <div className={`border-t-2 border-dashed ${dividerColor} w-full absolute`} />
+        </div>
       )}
 
       <div
-        className={classNames(
-          "relative px-10 py-5 flex",
-          isNotAccepted ? 'opacity-30' : '',
-          className,
-        )}
+        className="relative flex flex-col items-center"
       >
-        {/* Percentage-based background colour */}
-        <div
-          className={`absolute h-full ${backgroundColor} top-0 left-0`}
-          style={{
-            width: typeof acceptedCost === 'number' && showAcceptedState
-              ? `${acceptedCost}%`
-              : '100%'
-          }}
-        />
-
-        {/* Full-width background colour */}
-        <div
-          className={`absolute h-full w-full ${backgroundColor} top-0 left-0 opacity-50`}
-        />
-
-        {/* Content */}
-        <div className="z-10 items-center flex gap-x-10 justify-between w-full">
-          <ProjectTitle
-            acceptedCost={acceptedCost}
-            showCosts={showCosts}
-            project={project}
-            hideMainTitle={isMySubsequentProject}
+        <motion.div
+          animate={projectAnimation}
+          style={getMyProjectStyles(project, scenario)}
+          className={classNames(
+            "absolute p-5 flex overflow-hidden left-0 top-0",
+            className,
+          )}
+        >
+          {/* Percentage-based background colour */}
+          <div
+            className={`absolute h-full ${backgroundColor} top-0 left-0`}
+            style={{
+              width: typeof acceptedCost === 'number' && showingWinners
+                ? `${acceptedCost}%`
+                : '100%'
+            }}
           />
 
-          {/* Products */}
-          <div className="flex gap-x-10 flex-[20%]">
-            {/* Biodiversity */}
-            {typeof products.biodiversity === 'number' && (
-              <div
-                className={`h-[66px] w-[66px] rounded-lg flex items-center justify-center relative ${shadowColor}`}
-              >
-                <AdjustedProductCount
-                  count={products.biodiversity}
-                  accepted={acceptedCost}
-                />
-                <svg
-                  width="32"
-                  height="32"
-                  viewBox="0 0 32 32"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    opacity="0.7"
-                    d="M8.81169 7.68831C8.81169 3.71831 12.03 0.5 16 0.5C19.97 0.5 23.1884 3.71832 23.1884 7.68831C23.1884 8.30864 23.6912 8.81169 24.3116 8.81169C28.2817 8.81169 31.5 12.03 31.5 16C31.5 19.97 28.2817 23.1884 24.3116 23.1884C23.6913 23.1884 23.1884 23.6913 23.1884 24.3116C23.1884 28.2817 19.97 31.5 16 31.5C12.03 31.5 8.81169 28.2817 8.81169 24.3116C8.81169 23.6912 8.30864 23.1884 7.68831 23.1884C3.71832 23.1884 0.5 19.97 0.5 16C0.5 12.03 3.71831 8.81169 7.68831 8.81169C8.30873 8.81169 8.81169 8.30873 8.81169 7.68831Z"
-                    stroke="white"
-                  />
-                </svg>
-              </div>
-            )}
+          {/* Full-width background colour */}
+          <div
+            className={`absolute h-full w-full ${backgroundColor} top-0 left-0 opacity-50`}
+          />
 
-            {/* Nutrients */}
-            {typeof products.nutrients === 'number' && (
-              <div
-                className={`h-[66px] w-[66px] ${shadowColor} rounded-lg flex items-center justify-center relative`}
-              >
-                <AdjustedProductCount
-                  count={products.nutrients}
-                  accepted={acceptedCost}
-                />
-                <svg
-                  width="22"
-                  height="32"
-                  viewBox="0 0 22 32"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
+          {/* Content */}
+          <div className={classNames(
+            "z-10 items-center flex justify-between w-full",
+            showLoserStyles ? 'gap-x-4' : 'gap-x-10',
+          )}>
+            <ProjectTitle
+              acceptedCost={acceptedCost}
+              showAcceptedCosts={showCosts && showingWinners}
+              project={project}
+              projectCost={projectCost}
+              hideMainTitle={isMySubsequentProject}
+              showLoserStyles={showLoserStyles}
+            />
+
+            {/* Products */}
+            <div className={classNames(
+              'flex',
+              showLoserStyles ? 'gap-x-2' : 'gap-x-10 flex-[20%]',
+            )}>
+              {/* Biodiversity */}
+              <ProjectBiodiversity
+                count={products.biodiversity}
+                accepted={acceptedCost}
+                shadowColor={shadowColor}
+                showLoserStyles={showLoserStyles}
+              />
+
+              {/* Nutrients */}
+              <ProjectNutrients
+                count={products.nutrients}
+                accepted={acceptedCost}
+                shadowColor={shadowColor}
+                showLoserStyles={showLoserStyles}
+              />
+            </div>
+
+            {!showLoserStyles && (
+              <div className="flex gap-x-10 flex-[50%]">
+                {/* Bid */}
+                <motion.div
+                  variants={fadeInDown}
+                  initial="hidden"
+                  animate={showCosts ? 'visible' : '' }
+                  className="bg-white rounded-lg border border-black px-1 w-[95px]"
                 >
-                  <path
-                    opacity="0.7"
-                    d="M3.55382 28.7654L3.5538 28.7654C1.58991 27.0217 0.5 24.6703 0.5 22.2332C0.5 18.4038 2.4831 15.5249 5.04685 11.8362L5.05338 11.8268C6.98602 9.04625 9.20932 5.84757 10.9755 1.52781L10.9998 1.60143L11.0243 1.52726C12.7905 5.8473 15.0139 9.04614 16.9466 11.8268L16.9531 11.8361C19.5168 15.5249 21.5 18.4038 21.5 22.2332C21.5 24.6703 20.4101 27.0217 18.4462 28.7654C16.4949 30.498 13.7822 31.5 11 31.5C8.19741 31.5 5.51957 30.511 3.55382 28.7654Z"
-                    stroke="white"
-                  />
-                </svg>
+                  <div className="w-[29px] h-[29px] mx-auto relative bottom-3 flex justify-center items-center rounded-full bg-white border border-black">
+                    <HammerIcon />
+                  </div>
+                  <div className="text-center text-sm relative -mt-2">
+                    <p className="text-light-grey">
+                      {isBuyer ? 'Bid' : 'Offer'}
+                    </p>
+                    <p>£{adjustedCost.toLocaleString()}</p>
+                    {adjustedCost !== projectCost && (
+                      <p className={`${textColor} opacity-50`}>
+                        £{projectCost.toLocaleString()}
+                      </p>
+                    )}
+                  </div>
+                </motion.div>
+
+                {/* Discount */}
+                <motion.div
+                  variants={fadeInDown}
+                  initial="hidden"
+                  animate={
+                    (
+                      marketState >= WalkthroughMarketState.showing_surpluses &&
+                      !isNotAccepted
+                    ) ? 'visible' : ''
+                  }
+                  className="bg-white rounded-lg border border-black px-1 w-[95px]"
+                >
+                  <div className="w-[29px] h-[29px] mx-auto relative bottom-3 flex justify-center items-center rounded-full bg-white border border-black">
+                    <p className="text-black">
+                      {isBuyer ? '-' : '+'}
+                    </p>
+                  </div>
+                  <div className="text-center text-sm relative -mt-2">
+                    <p className="text-light-grey">
+                      {isBuyer ? 'Discount' : 'Bonus'}
+                    </p>
+                    <p>£{discountOrBonus.toLocaleString()}</p>
+                  </div>
+                </motion.div>
+
+                {/* Pays */}
+                <motion.div
+                  variants={fadeInDown}
+                  initial="hidden"
+                  animate={
+                    (
+                      marketState === WalkthroughMarketState.solved
+                      && !isNotAccepted
+                    ) ? 'visible' : ''
+                  }
+                  className="bg-white rounded-lg border border-black px-1 w-[95px]"
+                >
+                  <div className="w-[29px] h-[29px] mx-auto relative bottom-3 flex justify-center items-center rounded-full bg-white border border-black">
+                    {isBuyer ? <PoundcashTag /> : <CartPlus />}
+                  </div>
+                  <div className="text-center text-sm relative -mt-2">
+                    <p className="text-light-grey">
+                      {isBuyer ? 'Pays' : 'Received'}
+                    </p>
+                    <p>
+                      £{(calculatePayment(
+                        projectCost,
+                        discountOrBonus,
+                        accepted(projectCost),
+                        projectRoleId,
+                      )).toLocaleString()}
+                    </p>
+                  </div>
+                </motion.div>
               </div>
             )}
           </div>
-
-          <div className="flex gap-x-10 flex-[50%]">
-            {/* Bid */}
-            <motion.div
-              variants={fadeInDown}
-              initial="hidden"
-              animate={showCosts ? 'visible' : '' }
-              className="bg-white rounded-lg border border-black px-1 w-[95px]"
-            >
-              <div className="w-[29px] h-[29px] mx-auto relative bottom-3 flex justify-center items-center rounded-full bg-white border border-black">
-                <HammerIcon />
-              </div>
-              <div className="text-center text-sm relative -mt-2">
-                <p className="text-light-grey">
-                  {isBuyer ? 'Bid' : 'Offer'}
-                </p>
-                <p>£{adjustedCost.toLocaleString()}</p>
-                {adjustedCost !== projectCost && (
-                  <p className={`${textColor} opacity-50`}>
-                    £{projectCost.toLocaleString()}
-                  </p>
-                )}
-              </div>
-            </motion.div>
-
-            {/* Discount */}
-            <motion.div
-              variants={fadeInDown}
-              initial="hidden"
-              animate={
-                marketState >= WalkthroughMarketState.showing_surpluses && !isNotAccepted ? 'visible' : ''
-              }
-              className="bg-white rounded-lg border border-black px-1 w-[95px]"
-            >
-              <div className="w-[29px] h-[29px] mx-auto relative bottom-3 flex justify-center items-center rounded-full bg-white border border-black">
-                <p className="text-black">
-                  {isBuyer ? '-' : '+'}
-                </p>
-              </div>
-              <div className="text-center text-sm relative -mt-2">
-                <p className="text-light-grey">
-                  {isBuyer ? 'Discount' : 'Bonus'}
-                </p>
-                <p>£{discountOrBonus.toLocaleString()}</p>
-              </div>
-            </motion.div>
-
-            {/* Pays */}
-            <motion.div
-              variants={fadeInDown}
-              initial="hidden"
-              animate={
-                marketState === WalkthroughMarketState.solved && !isNotAccepted ? 'visible' : ''
-              }
-              className="bg-white rounded-lg border border-black px-1 w-[95px]"
-            >
-              <div className="w-[29px] h-[29px] mx-auto relative bottom-3 flex justify-center items-center rounded-full bg-white border border-black">
-                {isBuyer ? <PoundcashTag /> : <CartPlus />}
-              </div>
-              <div className="text-center text-sm relative -mt-2">
-                <p className="text-light-grey">
-                  {isBuyer ? 'Pays' : 'Received'}
-                </p>
-                <p>
-                  £{(calculatePayment(
-                    projectCost,
-                    discountOrBonus,
-                    accepted(projectCost),
-                    projectRoleId,
-                  )).toLocaleString()}
-                </p>
-              </div>
-            </motion.div>
-          </div>
-        </div>
+        </motion.div>
       </div>
     </motion.div>
   );

--- a/components/walkthroughs/Main/ProjectBiodiversity.tsx
+++ b/components/walkthroughs/Main/ProjectBiodiversity.tsx
@@ -1,0 +1,69 @@
+import AdjustedProductCount from "./AdjustedProductCount";
+
+type Props = {
+  count?: number;
+  accepted: number | boolean;
+  shadowColor: string;
+  showLoserStyles: boolean;
+};
+
+const ProjectBiodiversity = ({
+  count,
+  accepted,
+  shadowColor,
+  showLoserStyles,
+}: Props) => {
+  if (typeof count !== 'number') {
+    return null;
+  }
+
+  if (showLoserStyles) {
+    return (
+      <div className="flex gap-x-1">
+        <svg
+          width="32"
+          height="32"
+          viewBox="0 0 32 32"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            opacity="0.7"
+            d="M8.81169 7.68831C8.81169 3.71831 12.03 0.5 16 0.5C19.97 0.5 23.1884 3.71832 23.1884 7.68831C23.1884 8.30864 23.6912 8.81169 24.3116 8.81169C28.2817 8.81169 31.5 12.03 31.5 16C31.5 19.97 28.2817 23.1884 24.3116 23.1884C23.6913 23.1884 23.1884 23.6913 23.1884 24.3116C23.1884 28.2817 19.97 31.5 16 31.5C12.03 31.5 8.81169 28.2817 8.81169 24.3116C8.81169 23.6912 8.30864 23.1884 7.68831 23.1884C3.71832 23.1884 0.5 19.97 0.5 16C0.5 12.03 3.71831 8.81169 7.68831 8.81169C8.30873 8.81169 8.81169 8.30873 8.81169 7.68831Z"
+            fill="#6FCF97"
+            stroke="white"
+          />
+        </svg>
+        <div className="border border-black rounded-full bg-white w-[29px] h-[29px] flex justify-center items-center">
+          {count}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={`h-[66px] w-[66px] rounded-lg flex items-center justify-center relative ${shadowColor}`}
+    >
+      <AdjustedProductCount
+        count={count}
+        accepted={accepted}
+      />
+      <svg
+        width="32"
+        height="32"
+        viewBox="0 0 32 32"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          opacity="0.7"
+          d="M8.81169 7.68831C8.81169 3.71831 12.03 0.5 16 0.5C19.97 0.5 23.1884 3.71832 23.1884 7.68831C23.1884 8.30864 23.6912 8.81169 24.3116 8.81169C28.2817 8.81169 31.5 12.03 31.5 16C31.5 19.97 28.2817 23.1884 24.3116 23.1884C23.6913 23.1884 23.1884 23.6913 23.1884 24.3116C23.1884 28.2817 19.97 31.5 16 31.5C12.03 31.5 8.81169 28.2817 8.81169 24.3116C8.81169 23.6912 8.30864 23.1884 7.68831 23.1884C3.71832 23.1884 0.5 19.97 0.5 16C0.5 12.03 3.71831 8.81169 7.68831 8.81169C8.30873 8.81169 8.81169 8.30873 8.81169 7.68831Z"
+          stroke="white"
+        />
+      </svg>
+    </div>
+  )
+}
+
+export default ProjectBiodiversity;

--- a/components/walkthroughs/Main/ProjectNutrients.tsx
+++ b/components/walkthroughs/Main/ProjectNutrients.tsx
@@ -1,0 +1,69 @@
+import AdjustedProductCount from "./AdjustedProductCount";
+
+type Props = {
+  count?: number;
+  accepted: number | boolean;
+  shadowColor: string;
+  showLoserStyles: boolean;
+};
+
+const ProjectNutrients = ({
+  count,
+  accepted,
+  shadowColor,
+  showLoserStyles,
+}: Props) => {
+  if (typeof count !== 'number') {
+    return null;
+  }
+
+  if (showLoserStyles) {
+    return (
+      <div className="flex gap-x-1">
+        <svg
+          width="22"
+          height="32"
+          viewBox="0 0 22 32"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            opacity="0.7"
+            d="M3.55382 28.7654L3.5538 28.7654C1.58991 27.0217 0.5 24.6703 0.5 22.2332C0.5 18.4038 2.4831 15.5249 5.04685 11.8362L5.05338 11.8268C6.98602 9.04625 9.20932 5.84757 10.9755 1.52781L10.9998 1.60143L11.0243 1.52726C12.7905 5.8473 15.0139 9.04614 16.9466 11.8268L16.9531 11.8361C19.5168 15.5249 21.5 18.4038 21.5 22.2332C21.5 24.6703 20.4101 27.0217 18.4462 28.7654C16.4949 30.498 13.7822 31.5 11 31.5C8.19741 31.5 5.51957 30.511 3.55382 28.7654Z"
+            fill="#56CCF2"
+            stroke="white"
+          />
+        </svg>
+        <div className="border border-black rounded-full bg-white w-[29px] h-[29px] flex justify-center items-center">
+          {count}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={`h-[66px] w-[66px] ${shadowColor} rounded-lg flex items-center justify-center relative`}
+    >
+      <AdjustedProductCount
+        count={count}
+        accepted={accepted}
+      />
+      <svg
+        width="22"
+        height="32"
+        viewBox="0 0 22 32"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          opacity="0.7"
+          d="M3.55382 28.7654L3.5538 28.7654C1.58991 27.0217 0.5 24.6703 0.5 22.2332C0.5 18.4038 2.4831 15.5249 5.04685 11.8362L5.05338 11.8268C6.98602 9.04625 9.20932 5.84757 10.9755 1.52781L10.9998 1.60143L11.0243 1.52726C12.7905 5.8473 15.0139 9.04614 16.9466 11.8268L16.9531 11.8361C19.5168 15.5249 21.5 18.4038 21.5 22.2332C21.5 24.6703 20.4101 27.0217 18.4462 28.7654C16.4949 30.498 13.7822 31.5 11 31.5C8.19741 31.5 5.51957 30.511 3.55382 28.7654Z"
+          stroke="white"
+        />
+      </svg>
+    </div>
+  )
+}
+
+export default ProjectNutrients;

--- a/components/walkthroughs/Main/ProjectTitle.tsx
+++ b/components/walkthroughs/Main/ProjectTitle.tsx
@@ -6,31 +6,43 @@ import { FunctionComponent } from 'react';
 
 type Props = {
   project: WalkthroughProject;
+  projectCost: number,
   acceptedCost: number | boolean;
   hideMainTitle: boolean;
-  showCosts?: boolean;
+  showLoserStyles: boolean;
+  showAcceptedCosts?: boolean;
 }
 
 export const ProjectTitle: FunctionComponent<Props> = ({
   project,
+  projectCost,
   acceptedCost,
   hideMainTitle,
-  showCosts,
+  showAcceptedCosts,
+  showLoserStyles,
 }: Props) => {
   const { scenario } = useWalkthroughContext();
-  const { title, subtitle, accepted } = project;
-  const acceptedPercentage = showCosts && Number.isFinite(acceptedCost)
+  const { title, subtitle } = project;
+  const acceptedPercentage = showAcceptedCosts && Number.isFinite(acceptedCost)
     ? acceptedCost
     : null;
 
   return (
-    <div className="flex flex-col text-black text-center flex-[30%] min-w-[125px]">
+    <div className={classNames(
+      'flex flex-col text-black text-center whitespace-nowrap',
+      showLoserStyles ? '' : 'flex-[30%] min-w-[125px]',
+    )}>
       {!hideMainTitle && (
-        <p
-          className={classNames(isMyProject(scenario, project) ? 'font-bold' : '')}
-        >
-          {title}
-        </p>
+        <div className="flex flex-col">
+          <p
+            className={classNames(isMyProject(scenario, project) ? 'font-bold' : '')}
+          >
+            {title}
+          </p>
+          {showLoserStyles && (
+            <p>£{projectCost.toLocaleString()}</p>
+          )}
+        </div>
       )}
       {acceptedPercentage ? (
         <span className="bg-white rounded-full px-3 py-1 mt-1">

--- a/components/walkthroughs/Main/ProjectTitle.tsx
+++ b/components/walkthroughs/Main/ProjectTitle.tsx
@@ -27,28 +27,38 @@ export const ProjectTitle: FunctionComponent<Props> = ({
     ? acceptedCost
     : null;
 
+  const commonTextClassNames = 'overflow-hidden text-left text-ellipsis';
+
   return (
     <div className={classNames(
       'flex flex-col text-black text-center whitespace-nowrap',
-      showLoserStyles ? '' : 'flex-[30%] min-w-[125px]',
+      showLoserStyles ? 'w-[100px]' : 'flex-[30%] min-w-[125px]',
     )}>
       {!hideMainTitle && (
         <div className="flex flex-col">
           <p
-            className={classNames(isMyProject(scenario, project) ? 'font-bold' : '')}
+            className={classNames(
+              commonTextClassNames,
+              isMyProject(scenario, project) ? 'font-bold' : '',
+              commonTextClassNames,
+            )}
           >
             {title}
           </p>
           {showLoserStyles && (
-            <p>£{projectCost.toLocaleString()}</p>
+            <p className={commonTextClassNames}>
+              £{projectCost.toLocaleString()}
+            </p>
           )}
         </div>
       )}
-      {acceptedPercentage ? (
-        <span className="bg-white rounded-full px-3 py-1 mt-1">
-          Accepted: {acceptedPercentage}%
-        </span>
-      ): subtitle && <p>{subtitle}</p>}
+      {!showLoserStyles && (
+        acceptedPercentage ? (
+          <span className="bg-white rounded-full px-3 py-1 mt-1">
+            Accepted: {acceptedPercentage}%
+          </span>
+        ): subtitle && <p className={commonTextClassNames}>{subtitle}</p>
+      )}
     </div>
   );
 };

--- a/context/WalkthroughContext.tsx
+++ b/context/WalkthroughContext.tsx
@@ -5,10 +5,8 @@ import {
   WalkthroughProject,
   WalkthroughScenario,
 } from "@/types/walkthrough";
-import { getNextScenarioId, parseScenarioId } from "@/utils/walkthroughs";
+import { getNextScenarioId, isProjectEqual, parseScenarioId } from "@/utils/walkthroughs";
 import { useRouter } from "next/router";
-import isEqual from 'lodash.isequal';
-import omit from 'lodash.omit';
 import {
   createContext,
   useState,
@@ -128,10 +126,8 @@ export const WalkthroughProvider: FunctionComponent<WalkthroughProviderProps> = 
 
   const getProjectCost = useCallback((project: WalkthroughProject): number => {
     const { cost: dynamicProjectCost } = dynamicProjectCosts.find((item) => (
-      isEqual(
-        omit(item.project, ['accepted']),
-        omit(project, ['accepted']),
-      ))) ?? {};
+      isProjectEqual(item.project, project)
+    )) ?? {};
 
     if (dynamicProjectCost) {
       return dynamicProjectCost;

--- a/utils/walkthroughs.ts
+++ b/utils/walkthroughs.ts
@@ -1,6 +1,8 @@
 import { RoleId } from "@/types/roles";
 import { roles } from "data/roles";
 import { walkthroughsByRole } from "data/walkthroughs";
+import isEqual from "lodash.isequal";
+import omit from "lodash.omit";
 import { GetWalkthroughScenario, Walkthrough, WalkthroughProject, WalkthroughScenario } from "../types/walkthrough";
 
 const SCENARIO_ID_DELIMITER = '-';
@@ -124,3 +126,27 @@ export const isMyProject = (
   scenario: WalkthroughScenario,
   project: WalkthroughProject,
 ) => scenario.myProjects.includes(project);
+
+export const isProjectEqual = (
+  projectA: WalkthroughProject,
+  projectB: WalkthroughProject,
+) => {
+  const ignoredProperties = ['accepted'];
+
+  return isEqual(
+    omit(projectA, ignoredProperties),
+    omit(projectB, ignoredProperties)
+  );
+};
+
+export const includesProject = (
+  project: WalkthroughProject,
+  projectsToCheck: WalkthroughProject[],
+):boolean => !!projectsToCheck.find((checkedProject) => (
+  isProjectEqual(checkedProject, project)
+));
+
+export const findProjectIndex = (
+  project: WalkthroughProject,
+  projects: WalkthroughProject[],
+) => projects.findIndex((p) => isProjectEqual(p, project));


### PR DESCRIPTION
Adds some animations while calculating the market. Could probably keep tweaking this forever so I'll leave it for now as there are other things to do!

If the screen width is >= 1800px then the losing products will slide out to the left, like in the designs. If the screen is any smaller they will just slide up to the top and get hidden. Probably more that could be done to make this screen responsive but this is something anyway.


https://user-images.githubusercontent.com/5636273/202861969-cb891499-5da4-4341-ade2-0f9ece37a788.mov


https://user-images.githubusercontent.com/5636273/202861970-ff97b494-2609-4e71-9d5d-6d2187a5ad04.mov

