### PR TITLE
Ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Install
+      run: npm install
     - name: Lint
       run: npm run lint
     - name: Check types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on: pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Lint
+      run: npm run lint
+    - name: Check types
+      run: npm run typecheck


### PR DESCRIPTION
Adds a script that (once merged) runs whenever someone opens a pull request or pushes changes to that pull request. For now this runs linting and type checking. Once tests exist it can also be used to run those.

This works well when combined with [branch protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) to prevent anything being merged into the main branch of these checks fail. 

I can't do that myself as I don't have the relevant permissions but you go to the "Settings"" tab up at the top, then "Branches" and add a rule that looks something like this:

<img width="863" alt="image" src="https://user-images.githubusercontent.com/5636273/202903010-61c81b58-2bf3-46c4-ad75-3cadf1fe3486.png">


