### PR TITLE
fix: show other participant bids/offers once solve market pressed

### DIFF
--- a/components/walkthroughs/Main/MainContentBody.tsx
+++ b/components/walkthroughs/Main/MainContentBody.tsx
@@ -113,7 +113,6 @@ const MainContentBody = () => {
               scenario.buyerProjects,
               'buyer',
             )}
-            data={scenario}
           />
         </motion.div>
 

--- a/components/walkthroughs/Main/ParticipantsList.tsx
+++ b/components/walkthroughs/Main/ParticipantsList.tsx
@@ -16,7 +16,6 @@ type Props = {
   sellerProjects: WalkthroughProject[];
   losingBuyerProjects: WalkthroughProject[];
   losingSellerProjects: WalkthroughProject[];
-  data: WalkthroughScenario;
 };
 
 /**
@@ -72,7 +71,6 @@ const ParticipantsList = ({
   sellerProjects,
   losingBuyerProjects,
   losingSellerProjects,
-  data,
 }: Props) => {
   const { scenario, marketState } = useWalkthroughContext();
   const showingWinners = marketState >= WalkthroughMarketState.showing_winners;
@@ -111,7 +109,6 @@ const ParticipantsList = ({
                 includesProject(project, buyerProjects) ? 'buyer' : 'seller'
               }
               project={project}
-              options={data.options}
               isLoser={includesProject(project, allLosingProjects)}
               loserIndex={findProjectIndex(project, sortedLosingProjects)}
               isMyFirstProject={isMyFirstProject}

--- a/components/walkthroughs/Main/Project.tsx
+++ b/components/walkthroughs/Main/Project.tsx
@@ -5,7 +5,6 @@ import { classNames } from '@/utils/index';
 
 import {
   WalkthroughMarketState,
-  WalkthroughOptions,
   WalkthroughProject,
   WalkthroughScenario,
 } from '@/types/walkthrough';
@@ -32,7 +31,6 @@ const SHOW_LOSERS_MAX_SCREEN_WIDTH = 1700;
 type Props = {
   project: WalkthroughProject;
   projectRoleId: 'buyer' | 'seller';
-  options: WalkthroughOptions;
   isLoser: boolean;
   loserIndex?: number;
   className?: string;
@@ -246,7 +244,6 @@ const useProjectAnimation = (
 const Project = ({
   project,
   projectRoleId,
-  options,
   isLoser,
   loserIndex,
   className = '',
@@ -256,7 +253,9 @@ const Project = ({
 }: Props) => {
   const { marketState, scenario, getProjectCost } = useWalkthroughContext();
   const { discountOrBonus, products, accepted } = project;
-  const { showCosts } = options;
+  const showCosts =
+    isMyProject(scenario, project) ||
+    marketState > WalkthroughMarketState.solvable;
 
   const projectCost = getProjectCost(project);
   const acceptedCost = accepted(projectCost);

--- a/data/walkthroughs/scenarios/buyers/1.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.1/index.ts
@@ -69,7 +69,6 @@ export const getBuyerScenario1_1: GetWalkthroughScenario = (stage: number) => ({
     stages: 12,
     isFormEnabled: stage === 5,
     showDetailsWidget: stage >= 2,
-    showCosts: stage >= 3,
     showMaps: true,
     highlightedMapRegions: {
       buyer: stage >= 2 ? 21 : -1,

--- a/data/walkthroughs/scenarios/buyers/1.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.2/index.ts
@@ -59,7 +59,6 @@ export const getBuyerScenario1_2: GetWalkthroughScenario = (stage: number) => ({
     stages: 8,
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/buyers/1.3/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.3/index.ts
@@ -59,7 +59,6 @@ export const getBuyerScenario1_3: GetWalkthroughScenario = (stage: number) => ({
     stages: 8,
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/buyers/1.4/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.4/index.ts
@@ -61,7 +61,6 @@ export const getBuyerScenario1_4: GetWalkthroughScenario = (stage: number) => ({
     stages: 9,
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 3,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/buyers/2.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.1/index.ts
@@ -63,7 +63,6 @@ export const getBuyerScenario2_1: GetWalkthroughScenario = (stage: number) => ({
     stages: 10,
     isFormEnabled: stage === 3,
     showDetailsWidget: stage >= 2,
-    showCosts: stage >= 3,
     showMaps: true,
     highlightedMapRegions: {
       buyer: stage >= 2 ? 21 : -1,

--- a/data/walkthroughs/scenarios/buyers/2.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.2/index.ts
@@ -45,7 +45,6 @@ export const getBuyerScenario2_2: GetWalkthroughScenario = (stage: number) => ({
     stages: 8,
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/buyers/2.3/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.3/index.ts
@@ -46,7 +46,6 @@ export const getBuyerScenario2_3: GetWalkthroughScenario = (stage: number) => ({
     stages: 9,
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/buyers/3.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/3.1/index.ts
@@ -63,7 +63,6 @@ export const getBuyerScenario3_1: GetWalkthroughScenario = (stage: number) => ({
     stages: 10,
     isFormEnabled: stage === 3,
     showDetailsWidget: stage >= 2,
-    showCosts: stage >= 3,
     showMaps: true,
     highlightedMapRegions: {
       buyer: stage >= 2 ? 21 : -1,

--- a/data/walkthroughs/scenarios/buyers/3.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/3.2/index.ts
@@ -61,7 +61,6 @@ export const getBuyerScenario3_2: GetWalkthroughScenario = (stage: number) => ({
     stages: 9,
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/buyers/4.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/4.1/index.ts
@@ -68,7 +68,6 @@ export const getBuyerScenario4_1: GetWalkthroughScenario = (stage: number) => ({
     allowDivision: true,
     showDetailsWidget: stage >= 2,
     showDivisibleInput: true,
-    showCosts: stage >= 3,
     showMaps: true,
     highlightedMapRegions: {
       buyer: stage >= 2 ? 21 : -1,

--- a/data/walkthroughs/scenarios/buyers/4.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/4.2/index.ts
@@ -62,7 +62,6 @@ export const getBuyerScenario4_2: GetWalkthroughScenario = (stage: number) => ({
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
     showDivisibleInput: true,
-    showCosts: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/buyers/5.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/5.1/index.ts
@@ -71,7 +71,6 @@ export const getBuyerScenario5_1: GetWalkthroughScenario = (stage: number) => ({
     stages: 11,
     isFormEnabled: stage === 3,
     showDetailsWidget: stage >= 2,
-    showCosts: stage >= 3,
     showMaps: false,
     showParticipants: stage >= 3,
   },

--- a/data/walkthroughs/scenarios/buyers/5.2/index.ts
+++ b/data/walkthroughs/scenarios/buyers/5.2/index.ts
@@ -69,7 +69,6 @@ export const getBuyerScenario5_2: GetWalkthroughScenario = (stage: number) => ({
     stages: 11,
     isFormEnabled: stage === 3,
     showDetailsWidget: stage >= 2,
-    showCosts: stage >= 3,
     showMaps: true,
     showParticipants: stage >= 3,
   },

--- a/data/walkthroughs/scenarios/generic/1.1/index.ts
+++ b/data/walkthroughs/scenarios/generic/1.1/index.ts
@@ -250,7 +250,6 @@ export const getGenericScenario0_0: GetWalkthroughScenario = (
     stages: 22,
     isFormEnabled: false,
     showDetailsWidget: false,
-    showCosts: true,
     showMaps: true,
     highlightedMapRegions: getHighlightedMapRegions(stage),
     showParticipants: stage === 4 || (stage > 5 && stage < 12) || stage >= 13,

--- a/data/walkthroughs/scenarios/sellers/1.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.1/index.ts
@@ -69,7 +69,6 @@ export const getSellerScenario1_1: GetWalkthroughScenario = (
     stages: 11,
     isFormEnabled: stage === 4,
     showDetailsWidget: stage >= 2,
-    showCosts: stage >= 3,
     showMaps: true,
     highlightedMapRegions: {
       seller: stage >= 2 ? 3 : -1,

--- a/data/walkthroughs/scenarios/sellers/1.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.2/index.ts
@@ -61,7 +61,6 @@ export const getSellerScenario1_2: GetWalkthroughScenario = (
     stages: 8,
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/sellers/1.3/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.3/index.ts
@@ -61,7 +61,6 @@ export const getSellerScenario1_3: GetWalkthroughScenario = (
     stages: 8,
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/sellers/1.4/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.4/index.ts
@@ -63,7 +63,6 @@ export const getSellerScenario1_4: GetWalkthroughScenario = (
     stages: 9,
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 3,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/sellers/2.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.1/index.ts
@@ -65,7 +65,6 @@ export const getSellerScenario2_1: GetWalkthroughScenario = (
     stages: 10,
     isFormEnabled: stage === 3,
     showDetailsWidget: stage >= 2,
-    showCosts: stage >= 3,
     showMaps: true,
     highlightedMapRegions: {
       seller: stage >= 2 ? 3 : -1,

--- a/data/walkthroughs/scenarios/sellers/2.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.2/index.ts
@@ -47,7 +47,6 @@ export const getSellerScenario2_2: GetWalkthroughScenario = (
     stages: 8,
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/sellers/2.3/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.3/index.ts
@@ -48,7 +48,6 @@ export const getSellerScenario2_3: GetWalkthroughScenario = (
     stages: 9,
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/sellers/3.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/3.1/index.ts
@@ -65,7 +65,6 @@ export const getSellerScenario3_1: GetWalkthroughScenario = (
     stages: 10,
     isFormEnabled: stage === 3,
     showDetailsWidget: stage >= 2,
-    showCosts: stage >= 3,
     showMaps: true,
     highlightedMapRegions: {
       seller: stage >= 2 ? 3 : -1,

--- a/data/walkthroughs/scenarios/sellers/3.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/3.2/index.ts
@@ -63,7 +63,6 @@ export const getSellerScenario3_2: GetWalkthroughScenario = (
     stages: 9,
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/sellers/4.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/4.1/index.ts
@@ -72,7 +72,6 @@ export const getSellerScenario4_1: GetWalkthroughScenario = (
     stages: 12,
     isFormEnabled: stage === 5,
     showDetailsWidget: stage >= 2,
-    showCosts: stage >= 3,
     showMaps: true,
     highlightedMapRegions: {
       seller: stage >= 2 ? 3 : -1,

--- a/data/walkthroughs/scenarios/sellers/4.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/4.2/index.ts
@@ -64,7 +64,6 @@ export const getSellerScenario4_2: GetWalkthroughScenario = (
     stages: 8,
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/sellers/4.3/index.ts
+++ b/data/walkthroughs/scenarios/sellers/4.3/index.ts
@@ -65,7 +65,6 @@ export const getSellerScenario4_3: GetWalkthroughScenario = (
     stages: 9,
     isFormEnabled: stage === 1,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/data/walkthroughs/scenarios/sellers/5.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/5.1/index.ts
@@ -60,7 +60,6 @@ export const getSellerScenario5_1: GetWalkthroughScenario = (
     stages: 10,
     isFormEnabled: stage === 3,
     showDetailsWidget: stage >= 2,
-    showCosts: stage >= 3,
     showMaps: true,
     highlightedMapRegions: {
       seller: stage >= 2 ? 3 : -1,

--- a/data/walkthroughs/scenarios/sellers/5.2/index.ts
+++ b/data/walkthroughs/scenarios/sellers/5.2/index.ts
@@ -68,7 +68,6 @@ export const getSellerScenario5_2: GetWalkthroughScenario = (
     stages: 10,
     isFormEnabled: stage === 2,
     showDetailsWidget: stage >= 1,
-    showCosts: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
   },

--- a/types/walkthrough.ts
+++ b/types/walkthrough.ts
@@ -11,7 +11,6 @@ export interface WalkthroughOptions {
   allowDivision?: boolean;
   showDetailsWidget: boolean;
   showDivisibleInput?: boolean;
-  showCosts: boolean;
   showMaps: boolean;
   highlightedMapRegions?: WalkthroughHighlightedMapRegions;
   showParticipants: boolean;


### PR DESCRIPTION
From the client feedback:

![image](https://user-images.githubusercontent.com/5636273/204049263-ee8d34b9-3bfd-44c1-b6c4-f3bf0aa9b3ff.png)

Means we can drop another of the stage-based options too, the logic is quite clear and consistent there! That note is talking about a specific scenario at the start, but applies to them all.