### PR TITLE
fix: minor header and footer style tweaks

### DIFF
--- a/components/common/Nav/index.tsx
+++ b/components/common/Nav/index.tsx
@@ -19,13 +19,16 @@ export const Nav: FC<NavProps> = ({
   logoColor,
 }: NavProps) => (
   <nav
-    className={classNames('lg:flex justify-between items-end', className)}
+    className={classNames(
+      'lg:flex justify-between items-end flex-1',
+      className,
+    )}
     aria-label="Main Navigation"
   >
     <Link href="/" aria-label="Exeter Lindsay">
       <Logo color={logoColor} />
     </Link>
-    <ul className="lg:flex gap-x-10 xl:gap-x-16 text-light-grey">
+    <ul className="lg:flex gap-x-10 xl:gap-x-16 text-light-grey my-2 lg:my-0 space-y-2 lg:space-y-0">
       <li>
         <NavLink
           href="/"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -64,7 +64,7 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
         }}
       />
       <Nav
-        className="px-10 pb-8 pt-5"
+        className="px-10 lg:pb-8 pt-5"
         activeClassName="underline text-green-dark"
       />
       <Component


### PR DESCRIPTION
Noticed the icon in the footer was somehow misaligned, better now:

<img width="1673" alt="image" src="https://user-images.githubusercontent.com/5636273/204059407-25d44548-0fd1-4758-85fb-ea31c9706581.png">

Some quick tweaks for mobile while I'm there too.

<img width="473" alt="image" src="https://user-images.githubusercontent.com/5636273/204059524-e179bbda-6ee0-4170-90e8-8522fab1e4b3.png">