### PR TITLE
fix: only limit market info for scenario 1.4

### DIFF
--- a/components/common/Walkthrough/index.tsx
+++ b/components/common/Walkthrough/index.tsx
@@ -173,7 +173,11 @@ export const Walkthrough: FC = () => {
           myProjects={scenario.myProjects}
           buyerProjects={scenario.buyerProjects}
           sellerProjects={scenario.sellerProjects}
-          showCosts={marketState > WalkthroughMarketState.solvable}
+          showCosts={
+            scenario.options.limitMarketInfo
+              ? marketState > WalkthroughMarketState.solvable
+              : true
+          }
           showAllProjects={marketState < WalkthroughMarketState.solvable}
           showWinners={marketState >= WalkthroughMarketState.showing_winners}
           showSurpluses={

--- a/context/WalkthroughContext.tsx
+++ b/context/WalkthroughContext.tsx
@@ -17,6 +17,7 @@ import {
   WalkthroughScenario,
 } from '@/types/walkthrough';
 import { getNextScenarioId, parseScenarioId } from '@/utils/walkthroughs';
+import { useProjectsContext } from './ProjectsContext';
 
 type WalkthroughContextType = {
   scenarioId: string;
@@ -45,10 +46,11 @@ type WalkthroughProviderProps = {
 export const WalkthroughProvider: FunctionComponent<
   WalkthroughProviderProps
 > = ({ scenarioId, children }) => {
+  const { getProjectCost } = useProjectsContext();
   const { roleId, getScenario, walkthrough } = parseScenarioId(scenarioId);
   const [stage, setStage] = useState(1);
 
-  const scenario = getScenario(stage);
+  const scenario = getScenario(stage, { getProjectCost });
   const router = useRouter();
   const [marketState, setMarketState] = useState<WalkthroughMarketState>(
     WalkthroughMarketState.pending,

--- a/data/walkthroughs/scenarios/sellers/1.4/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.4/index.ts
@@ -65,5 +65,6 @@ export const getSellerScenario1_4: GetWalkthroughScenario = (
     showDetailsWidget: stage >= 1,
     showMaps: false,
     showParticipants: stage >= 1,
+    limitMarketInfo: true,
   },
 });

--- a/data/walkthroughs/scenarios/sellers/1.4/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.4/index.ts
@@ -3,68 +3,109 @@ import { sidebarContent1 } from './sidebar-content/1';
 import { sidebarContent8 } from './sidebar-content/8';
 import { sidebarContent9 } from './sidebar-content/9';
 
+const SIXTY_THOUSAND = 60000;
+const EIGHTY_THOUSAND = 80000;
+const ONE_HUNDRED_THOUSAND = 100000;
+
+const myProject = {
+  title: 'My Project',
+  cost: [SIXTY_THOUSAND, EIGHTY_THOUSAND, ONE_HUNDRED_THOUSAND],
+  discountOrBonus: 12000,
+  accepted: (value: number) => value === 60000,
+  products: { biodiversity: 2, nutrients: 3 },
+};
+
 export const getSellerScenario1_4: GetWalkthroughScenario = (
   stage: number,
-) => ({
-  myProjects: [
-    {
-      title: 'My Project',
-      cost: [60000, 80000, 100000],
-      discountOrBonus: 12000,
-      accepted: (value: number) => value === 60000,
-      products: { biodiversity: 2, nutrients: 3 },
+  { getProjectCost } = {},
+) => {
+  if (!getProjectCost) {
+    throw new Error(
+      'This scenario requires a getProjectCost function to be given',
+    );
+  }
+
+  const projectCost = getProjectCost(myProject);
+
+  return {
+    myProjects: [myProject],
+    buyerProjects: [
+      {
+        title: 'Buyer 1',
+        cost: 120000,
+        accepted: () => false,
+        discountOrBonus: 0,
+        products: { biodiversity: 3, nutrients: 4 },
+      },
+      {
+        title: 'Buyer 2',
+        cost: 180000,
+        accepted: () => true,
+        discountOrBonus: (() => {
+          if (projectCost === ONE_HUNDRED_THOUSAND) {
+            return 35000;
+          }
+
+          if (projectCost === EIGHTY_THOUSAND) {
+            return 35000;
+          }
+
+          return 38000;
+        })(),
+        products: { biodiversity: 3, nutrients: 2 },
+      },
+      {
+        title: 'Buyer 3',
+        cost: 70000,
+        accepted: () => projectCost !== ONE_HUNDRED_THOUSAND,
+        discountOrBonus: (() => {
+          if (projectCost === SIXTY_THOUSAND) {
+            return 4000;
+          }
+
+          return 0;
+        })(),
+        products: { biodiversity: 1, nutrients: 3 },
+      },
+    ],
+    sellerProjects: [
+      {
+        title: 'Seller 1',
+        cost: 120000,
+        accepted: () => true,
+        discountOrBonus: (() => {
+          if (projectCost === ONE_HUNDRED_THOUSAND) {
+            return 25000;
+          }
+
+          if (projectCost === EIGHTY_THOUSAND) {
+            return 20000;
+          }
+
+          return 16000;
+        })(),
+        products: { biodiversity: 4, nutrients: 2 },
+      },
+      {
+        title: 'Seller 2',
+        cost: 70000,
+        accepted: () => projectCost === EIGHTY_THOUSAND,
+        discountOrBonus: 5000,
+        products: { biodiversity: 1, nutrients: 3 },
+      },
+    ],
+    sidebarContent: {
+      1: sidebarContent1,
+      8: sidebarContent8,
+      9: sidebarContent9,
     },
-  ],
-  buyerProjects: [
-    {
-      title: 'Buyer 1',
-      cost: 120000,
-      accepted: () => false,
-      discountOrBonus: 0,
-      products: { biodiversity: 3, nutrients: 4 },
+    options: {
+      stages: 9,
+      isFormEnabled: stage === 1,
+      showDetailsWidget: stage >= 1,
+      showMaps: false,
+      showParticipants: stage >= 1,
+      limitMarketInfo: true,
     },
-    {
-      title: 'Buyer 2',
-      cost: 180000,
-      accepted: () => true,
-      discountOrBonus: 37500,
-      products: { biodiversity: 3, nutrients: 2 },
-    },
-    {
-      title: 'Buyer 3',
-      cost: 70000,
-      accepted: () => true,
-      discountOrBonus: 4000,
-      products: { biodiversity: 1, nutrients: 3 },
-    },
-  ],
-  sellerProjects: [
-    {
-      title: 'Seller 1',
-      cost: 120000,
-      accepted: () => true,
-      discountOrBonus: 16000,
-      products: { biodiversity: 4, nutrients: 2 },
-    },
-    {
-      title: 'Seller 2',
-      cost: 70000,
-      accepted: () => false,
-      discountOrBonus: 0,
-      products: { biodiversity: 1, nutrients: 3 },
-    },
-  ],
-  sidebarContent: {
-    1: sidebarContent1,
-    8: sidebarContent8,
-    9: sidebarContent9,
-  },
-  options: {
-    stages: 9,
-    isFormEnabled: stage === 1,
-    showDetailsWidget: stage >= 1,
-    showMaps: false,
-    showParticipants: stage >= 1,
-    limitMarketInfo: true,
-  },
-});
+  };
+};

--- a/pages/how-it-works/[scenarioId].tsx
+++ b/pages/how-it-works/[scenarioId].tsx
@@ -17,11 +17,11 @@ interface HowItWorksScenarioProps {
 const HowItWorksScenario: NextPage<HowItWorksScenarioProps> = ({
   scenarioId,
 }) => (
-  <WalkthroughProvider scenarioId={scenarioId}>
-    <ProjectsProvider>
+  <ProjectsProvider>
+    <WalkthroughProvider scenarioId={scenarioId}>
       <Walkthrough />
-    </ProjectsProvider>
-  </WalkthroughProvider>
+    </WalkthroughProvider>
+  </ProjectsProvider>
 );
 
 export const getStaticPaths: GetStaticPaths<HowItWorksScenarioParams> = () => ({

--- a/types/walkthrough.ts
+++ b/types/walkthrough.ts
@@ -25,7 +25,10 @@ export interface WalkthroughScenario {
   fixedMarketState?: WalkthroughMarketState;
 }
 
-export type GetWalkthroughScenario = (stage: number) => WalkthroughScenario;
+export type GetWalkthroughScenario = (
+  stage: number,
+  options?: { getProjectCost?: (project: Project) => number },
+) => WalkthroughScenario;
 
 export interface Walkthrough {
   title: string;

--- a/types/walkthrough.ts
+++ b/types/walkthrough.ts
@@ -11,6 +11,7 @@ export interface WalkthroughOptions {
   showMaps: boolean;
   highlightedMapRegions?: HighlightedMapRegions;
   showParticipants: boolean;
+  limitMarketInfo?: boolean;
 }
 
 export interface WalkthroughScenario {


### PR DESCRIPTION
I misread one of those points in the client feedback: 

![image](https://user-images.githubusercontent.com/5636273/204097828-a81ca666-6823-484a-8566-991e03732ca4.png)

We only want to hide the costs for other participants for seller scenario 1.4.

Also, it turns out that the discounts and bonuses and therefore the final payments need to be dynamic, according to the option they selected in the box. There is some inconsistency between the words in the feedback and what was provided in the attached table, so I have gone with what's in the table, but might be worth double-checking this!

<img width="817" alt="image" src="https://user-images.githubusercontent.com/5636273/204099262-c30196d5-3bc7-46fe-afef-6dbe81d7fe92.png">

And then comparing that against the outcomes for each of those input options:

<img width="1703" alt="image" src="https://user-images.githubusercontent.com/5636273/204099338-7d16186b-4ce4-4dda-9006-c5e7a07227ee.png">

<img width="1701" alt="image" src="https://user-images.githubusercontent.com/5636273/204099319-b1e67b79-9fd1-4edd-82d1-182fd20a5552.png">

<img width="1539" alt="image" src="https://user-images.githubusercontent.com/5636273/204099291-5af4f094-675d-4a07-8aac-aa8e26d344a5.png">
