### PR TITLE
Live demo index tweaks

### DIFF
--- a/components/common/NavLink/index.tsx
+++ b/components/common/NavLink/index.tsx
@@ -26,7 +26,9 @@ export const NavLink: FC<NavLinkProps> = ({
       aria-current={isCurrent ? 'page' : undefined}
       className={classNames(
         'underline-offset-8 text-lg',
-        isCurrent ? activeClassName : `hover:underline ${inactiveClassName}`,
+        isCurrent
+          ? activeClassName
+          : `hover:underline ${inactiveClassName ?? ''}`,
       )}
     >
       {children}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -166,7 +166,7 @@ const Home: NextPage = () => {
                 experience of the model and demonstrate how your choices can
                 affect outcomes in different circumstances.
               </p>
-              <Button text="Start trading" link="/" />
+              <Button text="Start trading" link="/live-demo" />
             </div>
 
             <div className="relative">

--- a/pages/live-demo/index.tsx
+++ b/pages/live-demo/index.tsx
@@ -7,31 +7,57 @@ type LiveDemoIndexProps = {
   demoFiles: DemoFile[];
 };
 
+const groupByCategories = (demoFiles: DemoFile[]) => {
+  const initialData: { [key in string]: DemoFile[] } = {};
+
+  return demoFiles.reduce((acc, demoFile) => {
+    const categoryDescription = demoFile.data.categories.join(', ');
+
+    return {
+      ...acc,
+      [categoryDescription]: [...(acc[categoryDescription] ?? []), demoFile],
+    };
+  }, initialData);
+};
+
 const LiveDemoIndex: NextPage<LiveDemoIndexProps> = ({
   demoFiles,
 }: LiveDemoIndexProps) => (
   <div className="relative">
-    <section className="mt-16" id="scenarios">
-      <h2 className="heading-2 mx-6'">Scenarios</h2>
-      <ul className="flex flex-wrap">
-        {demoFiles.map((demoFile) => (
-          <li
-            key={demoFile.slug}
-            className="items-center w-full md:w-1/2 xl:w-1/3 p-5"
-          >
-            <Link
-              className="max-w-[420px] mx-auto"
-              href={{
-                pathname: '/live-demo/[slug]',
-                query: {
-                  slug: demoFile.slug,
-                },
-              }}
-            >
-              {demoFile.data.title}
-            </Link>
-          </li>
-        ))}
+    <section className="mt-6 mx-10" id="scenarios">
+      <h2 className="heading-2">List of Markets</h2>
+      <ul>
+        {Object.entries(groupByCategories(demoFiles)).map(
+          ([categoryDescription, groupedDemoFiles]) => (
+            <li key={categoryDescription}>
+              <section className="mt-2 mb-8 ml-1">
+                <h3 className="text-green-dark text-xl font-bold">
+                  {categoryDescription}
+                </h3>
+                <ul className="flex flex-wrap">
+                  {groupedDemoFiles.map((demoFile) => (
+                    <li
+                      key={demoFile.slug}
+                      className="items-center w-full pt-3"
+                    >
+                      <Link
+                        className="underline-offset-8 text-lg hover:underline"
+                        href={{
+                          pathname: '/live-demo/[slug]',
+                          query: {
+                            slug: demoFile.slug,
+                          },
+                        }}
+                      >
+                        {demoFile.data.title}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            </li>
+          ),
+        )}
       </ul>
     </section>
   </div>


### PR DESCRIPTION
Makes the live demo index page look a little better:

<img width="1702" alt="image" src="https://user-images.githubusercontent.com/5636273/204128129-9a11dec3-a72c-4a6f-b664-2bb96ead70f6.png">

In one of their power point presentations they have this:

<img width="391" alt="image" src="https://user-images.githubusercontent.com/5636273/204128179-f1ebccef-4f51-41bb-8e67-ef155815b8b0.png">

I'm not really sure what "category description" refers to there, but my guess is that it comes from the `categories` array in the JSON files, so for now I have just joined and grouped by these.