### PR TITLE
feat: rename Live Demo to Market sandbox

### DIFF
--- a/components/common/Footer/index.test.tsx
+++ b/components/common/Footer/index.test.tsx
@@ -19,7 +19,7 @@ describe('Footer', () => {
       Home: '/',
       'About the model': '/about-the-model',
       'How it works': '/how-it-works',
-      'Live demo': '/live-demo',
+      'Market sandbox': '/market-sandbox',
     });
   });
 

--- a/components/common/MarketSandbox/index.test.tsx
+++ b/components/common/MarketSandbox/index.test.tsx
@@ -5,7 +5,7 @@ import { ProjectsContext } from '../../../context/ProjectsContext';
 import { getMarketParticipants } from '../../../test-utils/market';
 import { DemoData } from '../../../types/demo';
 import { MAP_REGION_PATHS } from '../MapRegion';
-import { LiveDemo } from './index';
+import { MarketSandbox } from './index';
 
 type WrapperProps = { children: ReactNode };
 
@@ -152,9 +152,9 @@ const getHighlightedMapRegionByKey = (key: string) => {
   return region;
 };
 
-describe('LiveDemo', () => {
+describe('MarketSandbox', () => {
   it('highlights the expected map regions', () => {
-    render(<LiveDemo data={multipleBidsScenario} />, { wrapper });
+    render(<MarketSandbox data={multipleBidsScenario} />, { wrapper });
 
     const highlightedMapPaths = getHighlightedMapRegions();
 
@@ -167,7 +167,7 @@ describe('LiveDemo', () => {
   });
 
   it('selects a single map region', async () => {
-    render(<LiveDemo data={multipleBidsScenario} />, { wrapper });
+    render(<MarketSandbox data={multipleBidsScenario} />, { wrapper });
 
     const region = getHighlightedMapRegionByKey('b1');
 
@@ -190,7 +190,7 @@ describe('LiveDemo', () => {
   });
 
   it('selects multiple map regions', async () => {
-    render(<LiveDemo data={multipleBidsScenario} />, { wrapper });
+    render(<MarketSandbox data={multipleBidsScenario} />, { wrapper });
 
     const region = getHighlightedMapRegionByKey('s1');
 

--- a/components/common/MarketSandbox/index.tsx
+++ b/components/common/MarketSandbox/index.tsx
@@ -17,7 +17,7 @@ import { MarketState } from '../../../types/market';
 import { HighlightedMapRegions } from '../../../types/map';
 import { isProjectEqual } from '../../../utils/walkthroughs';
 
-interface LiveDemoProps {
+interface MarketSandboxProps {
   data: DemoData;
 }
 
@@ -166,7 +166,9 @@ const getHighlightedMapRegions = (
   return regions;
 };
 
-export const LiveDemo: NextPage<LiveDemoProps> = ({ data }: LiveDemoProps) => {
+export const MarketSandbox: NextPage<MarketSandboxProps> = ({
+  data,
+}: MarketSandboxProps) => {
   const [marketState, setMarketState] = useState<MarketState>(0);
   const [result, setResult] = useState<Result>();
 

--- a/components/common/Nav/index.test.tsx
+++ b/components/common/Nav/index.test.tsx
@@ -24,7 +24,7 @@ describe('Nav', () => {
       Home: '/',
       'About the model': '/about-the-model',
       'How it works': '/how-it-works',
-      'Live demo': '/live-demo',
+      'Market sandbox': '/market-sandbox',
     });
   });
 

--- a/components/common/Nav/index.tsx
+++ b/components/common/Nav/index.tsx
@@ -58,11 +58,11 @@ export const Nav: FC<NavProps> = ({
       </li>
       <li>
         <NavLink
-          href="/live-demo"
+          href="/market-sandbox"
           activeClassName={activeClassName}
           inactiveClassName={inactiveClassName}
         >
-          Live demo
+          Market sandbox
         </NavLink>
       </li>
     </ul>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -166,7 +166,7 @@ const Home: NextPage = () => {
                 experience of the model and demonstrate how your choices can
                 affect outcomes in different circumstances.
               </p>
-              <Button text="Start trading" link="/live-demo" />
+              <Button text="Start trading" link="/market-sandbox" />
             </div>
 
             <div className="relative">

--- a/pages/market-sandbox/[slug].tsx
+++ b/pages/market-sandbox/[slug].tsx
@@ -3,24 +3,26 @@ import { ParsedUrlQuery } from 'querystring';
 import { DemoData } from '../../types/demo';
 import { getDemoFiles } from '../../utils/demo';
 import { ProjectsProvider } from '../../context/ProjectsContext';
-import { LiveDemo } from '../../components/common/LiveDemo';
+import { MarketSandbox } from '../../components/common/MarketSandbox';
 
-interface LiveDemoScenarioParams extends ParsedUrlQuery {
+interface MarketSandboxScenarioParams extends ParsedUrlQuery {
   slug: string;
 }
 
-interface LiveDemoScenarioProps {
+interface MarketSandboxScenarioProps {
   data: DemoData;
 }
 
-const LiveDemoScenario: NextPage<LiveDemoScenarioProps> = ({ data }) => (
+const MarketSandboxScenario: NextPage<MarketSandboxScenarioProps> = ({
+  data,
+}) => (
   <ProjectsProvider>
-    <LiveDemo data={data} />
+    <MarketSandbox data={data} />
   </ProjectsProvider>
 );
 
 export const getStaticPaths: GetStaticPaths<
-  LiveDemoScenarioParams
+  MarketSandboxScenarioParams
 > = async () => {
   const demoFiles = await getDemoFiles();
 
@@ -35,8 +37,8 @@ export const getStaticPaths: GetStaticPaths<
 };
 
 export const getStaticProps: GetStaticProps<
-  LiveDemoScenarioProps,
-  LiveDemoScenarioParams
+  MarketSandboxScenarioProps,
+  MarketSandboxScenarioParams
 > = async ({ params }) => {
   const demoFiles = await getDemoFiles();
   const demoFile = demoFiles.find(({ slug }) => slug === params?.slug);
@@ -55,4 +57,4 @@ export const getStaticProps: GetStaticProps<
   };
 };
 
-export default LiveDemoScenario;
+export default MarketSandboxScenario;

--- a/pages/market-sandbox/index.tsx
+++ b/pages/market-sandbox/index.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { getDemoFiles } from '../../utils/demo';
 import { DemoFile } from '../../types/demo';
 
-type LiveDemoIndexProps = {
+type MarketSandboxIndexProps = {
   demoFiles: DemoFile[];
 };
 
@@ -20,9 +20,9 @@ const groupByCategories = (demoFiles: DemoFile[]) => {
   }, initialData);
 };
 
-const LiveDemoIndex: NextPage<LiveDemoIndexProps> = ({
+const MarketSandboxIndex: NextPage<MarketSandboxIndexProps> = ({
   demoFiles,
-}: LiveDemoIndexProps) => (
+}: MarketSandboxIndexProps) => (
   <div className="relative">
     <section className="mt-6 mx-10" id="scenarios">
       <h2 className="heading-2">List of Markets</h2>
@@ -43,7 +43,7 @@ const LiveDemoIndex: NextPage<LiveDemoIndexProps> = ({
                       <Link
                         className="underline-offset-8 text-lg hover:underline"
                         href={{
-                          pathname: '/live-demo/[slug]',
+                          pathname: '/market-sandbox/[slug]',
                           query: {
                             slug: demoFile.slug,
                           },
@@ -64,7 +64,7 @@ const LiveDemoIndex: NextPage<LiveDemoIndexProps> = ({
 );
 
 export const getServerSideProps: GetServerSideProps<
-  LiveDemoIndexProps
+  MarketSandboxIndexProps
 > = async () => {
   const demoFiles = await getDemoFiles();
 
@@ -75,4 +75,4 @@ export const getServerSideProps: GetServerSideProps<
   };
 };
 
-export default LiveDemoIndex;
+export default MarketSandboxIndex;


### PR DESCRIPTION
Renames the route from `/live-demo` to `/market-sandbox` and the various components and things along with it