### PR TITLE
fix: xor bidding for the live demo

### DIFF
--- a/components/common/LiveDemo/index.tsx
+++ b/components/common/LiveDemo/index.tsx
@@ -26,7 +26,11 @@ interface LiveDemoProps {
 
 const API_URL = 'https://marketdesign.herokuapp.com/solve/lindsay2018';
 
-const isProjectAccepted = (bidder: DemoBidder, result?: Result) => {
+const isProjectAccepted = (
+  bidder: DemoBidder,
+  bid: DemoBid,
+  result?: Result,
+) => {
   // Assume a project is accepted by default (i.e. before we call the API to
   // solve the market).
   if (!result) {
@@ -34,8 +38,9 @@ const isProjectAccepted = (bidder: DemoBidder, result?: Result) => {
   }
 
   const { winning = 0 } =
-    result.problem.bidders.find(({ name }) => name === bidder.name)?.bids[0] ??
-    {};
+    result.problem.bidders
+      .find(({ name }) => name === bidder.name)
+      ?.bids.find(({ label }) => label === bid.label) ?? {};
 
   // Convert the `winning` property from the API data to a percentage.
   const acceptedPercentage = Math.abs(winning * 100);
@@ -57,7 +62,8 @@ const convertBidToProject = (
   const { q: products, v: cost, label } = bid;
   const { biodiversity = 0, nutrients = 0 } = products;
 
-  const discountOrBonus = result?.surplus_shares[title] ?? 0;
+  const accepted = isProjectAccepted(bidder, bid, result);
+  const discountOrBonus = accepted ? result?.surplus_shares[title] ?? 0 : 0;
 
   // Each `bid` contains an optional `label` with a very odd data structure, in
   // that it is used to indicate both the subtitle of the project and the
@@ -81,7 +87,7 @@ const convertBidToProject = (
       nutrients: Math.abs(nutrients),
     },
     discountOrBonus: Math.round(Math.abs(discountOrBonus)),
-    accepted: () => isProjectAccepted(bidder, result),
+    accepted: () => isProjectAccepted(bidder, bid, result),
   };
 };
 

--- a/components/common/Market/index.tsx
+++ b/components/common/Market/index.tsx
@@ -57,7 +57,7 @@ export const Market: FC<MarketProps> = ({
       {loadingBar && <TopProgressBar {...loadingBar} />}
       <LoadingOverlay text={loadingOverlayText} />
     </div>
-    <div className="z-10">
+    <div className="z-10 mb-8">
       <MarketScenario
         myProjects={myProjects}
         buyerProjects={buyerProjects}

--- a/components/common/MarketOutcome/index.tsx
+++ b/components/common/MarketOutcome/index.tsx
@@ -19,7 +19,10 @@ type MarketOutcomeProps = {
 const sumProjectCosts = (
   getProjectCost: (project: Project) => number,
   projects: Project[],
-) => projects.reduce((acc, project) => acc + getProjectCost(project), 0);
+) =>
+  projects
+    .filter((project) => !!project.accepted(getProjectCost(project)))
+    .reduce((acc, project) => acc + getProjectCost(project), 0);
 
 export const MarketOutcome: FC<MarketOutcomeProps> = ({
   className = '',

--- a/components/common/MarketParticipant/index.tsx
+++ b/components/common/MarketParticipant/index.tsx
@@ -401,7 +401,7 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
                 <motion.div
                   variants={fadeInDown}
                   initial="hidden"
-                  animate={showSurpluses ? 'visible' : ''}
+                  animate={showSurpluses && !isNotAccepted ? 'visible' : ''}
                   className="bg-white rounded-lg border border-black px-1 w-[95px]"
                   data-testid="discount-or-bonus"
                 >

--- a/components/common/MarketSandbox/index.test.tsx
+++ b/components/common/MarketSandbox/index.test.tsx
@@ -592,7 +592,7 @@ describe('MarketSandbox', () => {
       };
     });
 
-    render(<LiveDemo data={multipleBidsScenario} />, { wrapper });
+    render(<MarketSandbox data={multipleBidsScenario} />, { wrapper });
 
     const region = getHighlightedMapRegionByKey('s1');
 

--- a/components/common/Pagination/index.tsx
+++ b/components/common/Pagination/index.tsx
@@ -9,6 +9,7 @@ type PaginationProps = {
   hasPreviousPage?: boolean;
   onNextClick?: () => void;
   onPreviousClick?: () => void;
+  animateNextSteps?: boolean;
 };
 
 const noop = () => {};
@@ -20,6 +21,7 @@ export const Pagination: FC<PaginationProps> = ({
   hasPreviousPage,
   onNextClick = noop,
   onPreviousClick = noop,
+  animateNextSteps,
 }: PaginationProps) => (
   <motion.div layout className="text-center text-l w-full mt-2">
     {!!subtitle && <p className="text-green-dark mb-1">{subtitle}</p>}
@@ -40,7 +42,7 @@ export const Pagination: FC<PaginationProps> = ({
 
       {/* Next button */}
       <ArrowButton
-        className="animate-scale-large"
+        className={animateNextSteps ? 'animate-scale-large' : ''}
         onClick={onNextClick}
         hide={!hasNextPage}
         ariaLabel="Next"

--- a/components/common/ProjectDetails/index.tsx
+++ b/components/common/ProjectDetails/index.tsx
@@ -24,6 +24,7 @@ type ProjectDetailsProps = {
   onFormSubmit: () => void;
   onFormRevise?: () => void;
   roleId: RoleId;
+  animateNextSteps?: boolean;
 };
 
 const MAP_REGION_ICON_SIZE = 50;
@@ -75,6 +76,7 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
   onFormSubmit,
   onFormRevise,
   roleId,
+  animateNextSteps,
 }: ProjectDetailsProps) => {
   const { getProjectCost, setProjectCost } = useProjectsContext();
 
@@ -203,6 +205,7 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
                       name={priceInputNames[projectIndex]}
                       animate={
                         !!isFormEnabled &&
+                        animateNextSteps &&
                         animatedInputName === priceInputNames[projectIndex]
                       }
                       onInputChange={onCostInputChange}
@@ -224,7 +227,8 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
                 isDivisibleInputEnabled ? 'cursor-pointer' : '',
                 isFormEnabled &&
                   animatedInputName === 'is-divisible' &&
-                  isDivisibleInputEnabled
+                  isDivisibleInputEnabled &&
+                  animateNextSteps
                   ? 'animate-scale-large'
                   : '',
               )}
@@ -250,7 +254,7 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
               className={classNames(
                 'w-full rounded-lg bg-[#848484] text-white text-xs py-2',
                 isFormEnabled ? 'hover:bg-black cursor-pointer' : '',
-                isFormEnabled && !animatedInputName
+                isFormEnabled && !animatedInputName && animateNextSteps
                   ? 'animate-scale-large'
                   : '',
               )}

--- a/components/common/Sidebar/index.tsx
+++ b/components/common/Sidebar/index.tsx
@@ -21,6 +21,7 @@ type SidebarProps = {
   sidebarContent?: ReactNode;
   isFormEnabled?: boolean;
   isFormReviseEnabled?: boolean;
+  animateNextSteps?: boolean;
   hasFixedBids?: boolean;
   isDivisibleInputEnabled?: boolean;
   showDivisibleInput?: boolean;
@@ -44,6 +45,7 @@ export const SideBar: FC<SidebarProps> = ({
   sidebarContent,
   isFormEnabled,
   isFormReviseEnabled,
+  animateNextSteps,
   hasFixedBids,
   isDivisibleInputEnabled,
   showDivisibleInput,
@@ -71,6 +73,7 @@ export const SideBar: FC<SidebarProps> = ({
             onFormRevise={onFormRevise}
             roleId={roleId}
             projects={projects}
+            animateNextSteps={animateNextSteps}
           />
         )}
 
@@ -97,6 +100,7 @@ export const SideBar: FC<SidebarProps> = ({
           hasPreviousPage={hasPreviousPage}
           onNextClick={onNextClick}
           onPreviousClick={onPreviousClick}
+          animateNextSteps={animateNextSteps}
         />
 
         {/* Walkthrough Description text */}

--- a/components/common/Sidebar/index.tsx
+++ b/components/common/Sidebar/index.tsx
@@ -7,6 +7,7 @@ import { DescriptionBox } from '../DescriptionBox';
 import { ProjectDetails } from '../ProjectDetails';
 import { RoleId } from '../../../types/roles';
 import { Project } from '../../../types/project';
+import { classNames } from '../../../utils';
 
 type SidebarProps = {
   title: string;
@@ -86,7 +87,10 @@ export const SideBar: FC<SidebarProps> = ({
             exit="hidden"
             layout
             onClick={onSolveMarketClick}
-            className="text-center border-2 border-black rounded-lg p-3 text-black text-l hover:bg-black hover:text-white duration-300 animate-scale"
+            className={classNames(
+              'text-center border-2 border-black rounded-lg p-3 text-black text-l hover:bg-black hover:text-white duration-300',
+              animateNextSteps ? 'animate-scale' : '',
+            )}
           >
             Solve Market
           </motion.button>

--- a/components/common/Walkthrough/index.tsx
+++ b/components/common/Walkthrough/index.tsx
@@ -152,6 +152,7 @@ export const Walkthrough: FC = () => {
     <MainContainer>
       <SideBar
         hasFixedBids
+        animateNextSteps
         title={walkthrough.title}
         subtitle={getWalkthroughTitle(roleId, walkthroughIndex)}
         hasNextPage={hasNextStage}

--- a/types/result.ts
+++ b/types/result.ts
@@ -5,6 +5,7 @@ export type Bid = {
     nutrients: number;
   };
   winning?: number;
+  label?: string;
   divisibility?: number;
 };
 


### PR DESCRIPTION
Fixes and tests some things around XOR bidding for the live demo:

<img width="1699" alt="image" src="https://user-images.githubusercontent.com/5636273/204350217-1e8debf3-3953-4c12-b6ba-7c5366830b24.png">

Plus a fix to only animate the next steps for the walkthroughs (the input pulsing etc.). Feels a bit weird for the live demo!