### PR TITLE
Add bottom margin to "MarketOutcome" Component.

### DIFF
--- a/components/common/MarketOutcome/index.tsx
+++ b/components/common/MarketOutcome/index.tsx
@@ -34,7 +34,7 @@ export const MarketOutcome: FC<MarketOutcomeProps> = ({
   return (
     <div
       className={classNames(
-        'bg-blue-light px-10 py-5 rounded-lg flex items-center gap-x-12 select-none',
+        'bg-blue-light px-10 py-5 mb-6 rounded-lg flex items-center gap-x-12 select-none',
         className,
       )}
     >


### PR DESCRIPTION
Add bottom margin to "MarketOutcome" Component.
<img width="1040" alt="Screenshot 2022-11-29 at 10 27 31" src="https://user-images.githubusercontent.com/26447097/204491099-59f706ab-4789-45b7-ac8d-bd088f5db1f4.png">
