### PR TITLE
fix: transparent background for project bars

### DIFF
--- a/components/common/MarketParticipant/index.tsx
+++ b/components/common/MarketParticipant/index.tsx
@@ -310,7 +310,7 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
             isMyLastProject,
           )}
           className={classNames(
-            'absolute flex overflow-hidden left-0 top-0',
+            'absolute flex overflow-hidden left-0 top-0 bg-white',
             className,
           )}
         >


### PR DESCRIPTION
A tweak based on the comments in https://github.com/curiousways/marketdesign/pull/79 (moves that white background to the element with the rounded borders, rather than removing entirely

<img width="777" alt="image" src="https://user-images.githubusercontent.com/5636273/204497255-264ce6e7-f9e7-470d-9804-9b2a8e0d67a1.png">
