### PR TITLE
Live demo investor bidding

### DIFF
--- a/components/common/MarketOutcome/index.test.tsx
+++ b/components/common/MarketOutcome/index.test.tsx
@@ -9,7 +9,8 @@ const wrapper = ({ children }: WrapperProps) => (
   <ProjectsContext.Provider
     value={{
       setProjectCost: jest.fn(),
-      getProjectCost: jest.fn(({ cost }) =>
+      getProjectCost: jest.fn(),
+      getAcceptedProjectCost: jest.fn(({ cost }) =>
         Array.isArray(cost) ? cost[0] : cost,
       ),
     }}

--- a/components/common/MarketOutcome/index.tsx
+++ b/components/common/MarketOutcome/index.tsx
@@ -30,9 +30,9 @@ export const MarketOutcome: FC<MarketOutcomeProps> = ({
   sellerProjects,
   isMarketSolved,
 }: MarketOutcomeProps) => {
-  const { getProjectCost } = useProjectsContext();
-  const totalBids = sumProjectCosts(getProjectCost, buyerProjects);
-  const totalOffers = sumProjectCosts(getProjectCost, sellerProjects);
+  const { getAcceptedProjectCost } = useProjectsContext();
+  const totalBids = sumProjectCosts(getAcceptedProjectCost, buyerProjects);
+  const totalOffers = sumProjectCosts(getAcceptedProjectCost, sellerProjects);
 
   return (
     <div

--- a/components/common/MarketParticipant/index.tsx
+++ b/components/common/MarketParticipant/index.tsx
@@ -62,56 +62,87 @@ const calculatePayment = (
   return Math.round(adjustedCost + discountOrBonus);
 };
 
-const getMyProjectStyles = (
+const getBorderRadiusStyles = (
   isMyProject?: boolean,
   isMyFirstProject?: boolean,
   isMyLastProject?: boolean,
 ): CSSProperties => {
   const borderRadius = '0.5rem';
-  const borderWidth = '2px';
-  const borderColor = 'black';
-  const borderStyle = 'solid';
 
   if (!isMyProject) {
     return { borderRadius };
   }
 
-  const myProjectStyles: CSSProperties = {
-    borderRightColor: borderColor,
-    borderLeftColor: borderColor,
-    borderRightStyle: borderStyle,
-    borderLeftStyle: borderStyle,
-    borderRightWidth: borderWidth,
-    borderLeftWidth: borderWidth,
-  };
+  const styles: CSSProperties = {};
 
   if (isMyFirstProject) {
-    Object.assign(myProjectStyles, {
-      borderTopColor: borderColor,
-      borderTopStyle: borderStyle,
-      borderTopWidth: borderWidth,
+    Object.assign(styles, {
       borderTopLeftRadius: borderRadius,
       borderTopRightRadius: borderRadius,
     });
   }
 
   if (isMyLastProject) {
-    Object.assign(myProjectStyles, {
-      borderBottomColor: borderColor,
-      borderBottomStyle: borderStyle,
-      borderBottomWidth: borderWidth,
+    Object.assign(styles, {
       borderBottomLeftRadius: borderRadius,
       borderBottomRightRadius: borderRadius,
     });
+  }
+
+  return styles;
+};
+
+const getMyProjectStyles = (
+  isMyProject?: boolean,
+  isMyFirstProject?: boolean,
+  isMyLastProject?: boolean,
+): CSSProperties => {
+  const styles = getBorderRadiusStyles(
+    isMyProject,
+    isMyFirstProject,
+    isMyLastProject,
+  );
+
+  const borderWidth = '2px';
+  const borderColor = 'black';
+  const borderStyle = 'solid';
+
+  if (!isMyProject) {
+    return styles;
+  }
+
+  Object.assign(styles, {
+    borderRightColor: borderColor,
+    borderLeftColor: borderColor,
+    borderRightStyle: borderStyle,
+    borderLeftStyle: borderStyle,
+    borderRightWidth: borderWidth,
+    borderLeftWidth: borderWidth,
+  });
+
+  if (isMyFirstProject) {
+    Object.assign(styles, {
+      borderTopColor: borderColor,
+      borderTopStyle: borderStyle,
+      borderTopWidth: borderWidth,
+    });
+  }
+
+  if (isMyLastProject) {
+    Object.assign(styles, {
+      borderBottomColor: borderColor,
+      borderBottomStyle: borderStyle,
+      borderBottomWidth: borderWidth,
+    });
 
     if (!isMyFirstProject) {
-      Object.assign(myProjectStyles, {
+      Object.assign(styles, {
         marginTop: 0,
       });
     }
   }
 
-  return myProjectStyles;
+  return styles;
 };
 
 const useRowAnimation = (
@@ -291,6 +322,15 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
   // Adjust metrics for projects that were only partially accepted.
   const adjustedCost = getAdjustedCost(projectCost, accepted);
 
+  // Because of the way some project bars get merged and the discount/pays boxes
+  // float between the bars we can't use overflow: hidden here and instead need
+  // to apply the border radius to multiple elements.
+  const borderRadiusStyles = getBorderRadiusStyles(
+    isMyProject,
+    isMyFirstProject,
+    isMyLastProject,
+  );
+
   return (
     <motion.div
       data-testid={`${isLoser ? 'losing-' : ''}${projectRoleId}-participant`}
@@ -323,6 +363,7 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
           <div
             className={`absolute h-full ${backgroundColor} top-0 left-0`}
             style={{
+              ...borderRadiusStyles,
               width:
                 typeof accepted === 'number' && showWinners
                   ? `${accepted}%`
@@ -332,6 +373,7 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
 
           {/* Full-width background colour */}
           <div
+            style={borderRadiusStyles}
             className={`absolute h-full w-full ${backgroundColor} top-0 left-0 opacity-50`}
           />
 

--- a/components/common/MarketParticipant/index.tsx
+++ b/components/common/MarketParticipant/index.tsx
@@ -11,6 +11,7 @@ import { MarketParticipantTitle } from '../MarketParticipantTitle';
 import { Products } from '../../../types/products';
 import { BiodiversityCount } from '../BiodiversityCount';
 import { NutrientCount } from '../NutrientCount';
+import { getAdjustedCost } from '../../../utils/project';
 
 const PROJECT_HEIGHT = 120;
 const PROJECT_WIDTH = 800;
@@ -42,9 +43,6 @@ type MarketParticipantProps = {
   isGroupedProject?: boolean;
   totalCost: number;
 };
-
-const getAdjustedCost = (cost: number, accepted: boolean | number) =>
-  typeof accepted === 'number' ? (accepted / 100) * cost : cost;
 
 const calculatePayment = (
   cost: number,

--- a/components/common/MarketParticipant/index.tsx
+++ b/components/common/MarketParticipant/index.tsx
@@ -38,7 +38,8 @@ type MarketParticipantProps = {
   showWinners?: boolean;
   showSurpluses?: boolean;
   isMarketSolved?: boolean;
-  showGroupResults?: boolean;
+  showResults?: boolean;
+  isGroupedProject?: boolean;
   totalCost: number;
 };
 
@@ -50,9 +51,11 @@ const calculatePayment = (
   discountOrBonus: number,
   accepted: boolean | number,
   projectRoleId: RoleId,
-  isSplitProject: boolean,
+  isGroupedProject?: boolean,
 ) => {
-  const adjustedCost = isSplitProject ? cost : getAdjustedCost(cost, accepted);
+  const adjustedCost = isGroupedProject
+    ? cost
+    : getAdjustedCost(cost, accepted);
 
   if (projectRoleId === 'buyer') {
     return adjustedCost - discountOrBonus;
@@ -263,15 +266,15 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
   showWinners,
   showSurpluses,
   isMarketSolved,
-  showGroupResults,
+  showResults,
   totalCost,
+  isGroupedProject,
 }: MarketParticipantProps) => {
   const isBuyer = projectRoleId === 'buyer';
 
   const showLoserStyles = isLoser && showWinners;
   const isNotAccepted = showWinners && !accepted;
-  const isSplitProject = !!(totalCost && totalCost !== projectCost);
-  const shiftResults = isSplitProject && showGroupResults;
+  const shiftResults = isGroupedProject && showResults;
 
   const rowAnimation = useRowAnimation(showLoserStyles, isMySubsequentProject);
 
@@ -406,7 +409,7 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
                   variants={fadeInDown}
                   initial="hidden"
                   animate={
-                    showSurpluses && !isNotAccepted && showGroupResults
+                    showSurpluses && !isNotAccepted && showResults
                       ? 'visible'
                       : ''
                   }
@@ -436,7 +439,7 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
                   variants={fadeInDown}
                   initial="hidden"
                   animate={
-                    isMarketSolved && !isNotAccepted && showGroupResults
+                    isMarketSolved && !isNotAccepted && showResults
                       ? 'visible'
                       : ''
                   }
@@ -459,11 +462,11 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
                       <p>
                         £
                         {calculatePayment(
-                          totalCost ?? projectCost,
+                          isGroupedProject ? totalCost : projectCost,
                           discountOrBonus,
                           accepted,
                           projectRoleId,
-                          isSplitProject,
+                          isGroupedProject,
                         ).toLocaleString()}
                       </p>
                     </div>

--- a/components/common/MarketParticipantList/index.test.tsx
+++ b/components/common/MarketParticipantList/index.test.tsx
@@ -53,7 +53,7 @@ const sellerProjects = [
   },
 ];
 
-describe('MarketOutcome', () => {
+describe('MarketParticipantList', () => {
   it('renders some buyer and seller participants with all of the expected costs', () => {
     render(
       <MarketParticipantList
@@ -332,5 +332,55 @@ describe('MarketOutcome', () => {
     expect(
       within(participants[3]).getByTestId('market-participant-title'),
     ).toHaveTextContent('Seller 2');
+  });
+
+  it('groups investor projects', () => {
+    render(
+      <MarketParticipantList
+        myProjects={[]}
+        losingProjects={[]}
+        buyerProjects={[
+          {
+            title: 'Investor',
+            subtitle: 'Biodiversity',
+            cost: 10000,
+            products: { biodiversity: 1, nutrients: 0 },
+            accepted: () => 50,
+            discountOrBonus: 2500,
+            groupId: 'investor',
+          },
+          {
+            title: 'Investor',
+            subtitle: 'Nutrients',
+            cost: 18000,
+            products: { biodiversity: 0, nutrients: 2 },
+            accepted: () => 75,
+            discountOrBonus: 2500,
+            groupId: 'investor',
+          },
+        ]}
+        sellerProjects={[]}
+        roleId="seller"
+        showCosts
+        showSurpluses
+        showWinners
+      />,
+      { wrapper },
+    );
+
+    const { buyers, sellers } = getMarketParticipants();
+
+    expect(buyers).toHaveLength(2);
+    expect(sellers).toHaveLength(0);
+
+    expect(buyers[0].title).toHaveTextContent(/^InvestorAccepted: 50%$/);
+    expect(buyers[0].bidOrOffer).toHaveTextContent('£10,000');
+    expect(buyers[0].discountOrBonus).toHaveStyle({ opacity: 0 });
+    expect(buyers[0].paysOrReceived).toHaveStyle({ opacity: 0 });
+
+    expect(buyers[1].title).toHaveTextContent(/^InvestorAccepted: 75%$/);
+    expect(buyers[1].bidOrOffer).toHaveTextContent('£18,000');
+    expect(buyers[1].discountOrBonus).toHaveTextContent('£2,500');
+    expect(buyers[1].paysOrReceived).toHaveTextContent('£16,000');
   });
 });

--- a/components/common/MarketParticipantList/index.test.tsx
+++ b/components/common/MarketParticipantList/index.test.tsx
@@ -10,6 +10,15 @@ const wrapper = ({ children }: WrapperProps) => (
   <ProjectsContext.Provider
     value={{
       setProjectCost: jest.fn(),
+      getAcceptedProjectCost: jest.fn((project) => {
+        const cost = Array.isArray(project.cost)
+          ? project.cost[0]
+          : project.cost;
+
+        const accepted = project.accepted(cost);
+
+        return typeof accepted === 'number' ? (accepted / 100) * cost : cost;
+      }),
       getProjectCost: jest.fn(({ cost }) =>
         Array.isArray(cost) ? cost[0] : cost,
       ),

--- a/components/common/MarketParticipantList/index.tsx
+++ b/components/common/MarketParticipantList/index.tsx
@@ -85,7 +85,7 @@ export const MarketParticipantList: FC<MarketParticipantListProps> = ({
   showSurpluses,
   isMarketSolved,
 }: MarketParticipantListProps) => {
-  const { getProjectCost } = useProjectsContext();
+  const { getProjectCost, getAcceptedProjectCost } = useProjectsContext();
   const sortedProjects = sortMyProjects(
     myProjects,
     buyerProjects,
@@ -123,14 +123,7 @@ export const MarketParticipantList: FC<MarketParticipantListProps> = ({
         // The total cost for all projects in a grop is needed for the case
         // where a project comprises multple "sub-projects" (e.g. investor bidding).
         const totalCost = groupedProjects
-          .map((groupedProject) => {
-            const groupedProjectCost = getProjectCost(groupedProject);
-            const accepted = groupedProject.accepted(groupedProjectCost);
-
-            return typeof accepted === 'number'
-              ? (accepted / 100) * groupedProjectCost
-              : groupedProjectCost;
-          })
+          .map(getAcceptedProjectCost)
           .reduce((a, b) => a + b, 0);
 
         const isGroupedProject = !!groupedProjects.length;

--- a/components/common/MarketParticipantList/index.tsx
+++ b/components/common/MarketParticipantList/index.tsx
@@ -133,6 +133,8 @@ export const MarketParticipantList: FC<MarketParticipantListProps> = ({
           })
           .reduce((a, b) => a + b, 0);
 
+        const isGroupedProject = !!groupedProjects.length;
+
         return (
           <li key={JSON.stringify(project)}>
             <MarketParticipant
@@ -159,10 +161,11 @@ export const MarketParticipantList: FC<MarketParticipantListProps> = ({
               showWinners={showWinners}
               showSurpluses={showSurpluses}
               isMarketSolved={isMarketSolved}
-              showGroupResults={
-                !groupedProjects.length ||
+              showResults={
+                !isGroupedProject ||
                 project === groupedProjects[groupedProjects.length - 1]
               }
+              isGroupedProject={isGroupedProject}
               totalCost={totalCost}
             />
           </li>

--- a/components/common/MarketParticipantList/index.tsx
+++ b/components/common/MarketParticipantList/index.tsx
@@ -116,6 +116,23 @@ export const MarketParticipantList: FC<MarketParticipantListProps> = ({
 
         const projectCost = getProjectCost(project);
 
+        const groupedProjects = project.groupId
+          ? sortedProjects.filter(({ groupId }) => groupId === project.groupId)
+          : [];
+
+        // The total cost for all projects in a grop is needed for the case
+        // where a project comprises multple "sub-projects" (e.g. investor bidding).
+        const totalCost = groupedProjects
+          .map((groupedProject) => {
+            const groupedProjectCost = getProjectCost(groupedProject);
+            const accepted = groupedProject.accepted(groupedProjectCost);
+
+            return typeof accepted === 'number'
+              ? (accepted / 100) * groupedProjectCost
+              : groupedProjectCost;
+          })
+          .reduce((a, b) => a + b, 0);
+
         return (
           <li key={JSON.stringify(project)}>
             <MarketParticipant
@@ -142,6 +159,11 @@ export const MarketParticipantList: FC<MarketParticipantListProps> = ({
               showWinners={showWinners}
               showSurpluses={showSurpluses}
               isMarketSolved={isMarketSolved}
+              showGroupResults={
+                !groupedProjects.length ||
+                project === groupedProjects[groupedProjects.length - 1]
+              }
+              totalCost={totalCost}
             />
           </li>
         );

--- a/components/common/MarketSandbox/index.test.tsx
+++ b/components/common/MarketSandbox/index.test.tsx
@@ -835,12 +835,12 @@ describe('MarketSandbox', () => {
     expect(buyers[0].title).toHaveTextContent(/^InvestorAccepted: 75%$/);
     expect(buyers[0].bidOrOffer).toHaveTextContent('£6,000');
     expect(buyers[0].discountOrBonus).toHaveTextContent('£2,167');
-    expect(buyers[0].paysOrReceived).toHaveTextContent('£3,833');
+    expect(buyers[0].paysOrReceived).toHaveTextContent('£5,333');
 
     expect(buyers[1].title).toHaveTextContent(/^Accepted: 50%$/);
     expect(buyers[1].bidOrOffer).toHaveTextContent('£1,500');
-    expect(buyers[1].discountOrBonus).toHaveTextContent('£2,167');
-    expect(buyers[1].paysOrReceived).toHaveTextContent('£-667');
+    expect(buyers[0].discountOrBonus).toHaveTextContent('£2,167');
+    expect(buyers[0].paysOrReceived).toHaveTextContent('£5,333');
 
     expect(within(marketOutcome).getByTestId('total-bids')).toHaveTextContent(
       '£25,000',

--- a/components/common/MarketSandbox/index.test.tsx
+++ b/components/common/MarketSandbox/index.test.tsx
@@ -88,7 +88,7 @@ const singleBidScenario: DemoData = {
           name: 'buyer 1',
           bids: [
             {
-              v: 8000,
+              v: 25000,
               q: {
                 biodiversity: -1,
                 nutrients: -3,
@@ -600,7 +600,7 @@ describe('MarketSandbox', () => {
     const projectDetails = await screen.findByTestId('project-details');
     const textInput = within(projectDetails).getByRole('textbox');
 
-    fireEvent.change(textInput, { target: { value: '15000' } });
+    fireEvent.change(textInput, { target: { value: '30000' } });
 
     expect(textInput).toBeValid();
 
@@ -610,7 +610,7 @@ describe('MarketSandbox', () => {
     const marketOutcome = await screen.findByTestId('market-outcome');
     const { buyers, sellers } = getMarketParticipants();
 
-    expect(findBid(requestState!.bidders, 'buyer 1').v).toBe(15000);
+    expect(findBid(requestState!.bidders, 'buyer 1').v).toBe(30000);
 
     expect(sellers).toHaveLength(1);
     expect(buyers).toHaveLength(1);
@@ -621,9 +621,9 @@ describe('MarketSandbox', () => {
     expect(sellers[0].paysOrReceived).toHaveTextContent('£13,500');
 
     expect(buyers[0].title).toHaveTextContent('Buyer 1Accepted: 50%');
-    expect(buyers[0].bidOrOffer).toHaveTextContent('£7,500£15,000');
+    expect(buyers[0].bidOrOffer).toHaveTextContent('£15,000£30,000');
     expect(buyers[0].discountOrBonus).toHaveTextContent('£2,500');
-    expect(buyers[0].paysOrReceived).toHaveTextContent('£5,000');
+    expect(buyers[0].paysOrReceived).toHaveTextContent('£12,500');
 
     expect(within(marketOutcome).getByTestId('total-bids')).toHaveTextContent(
       '£15,000',
@@ -843,7 +843,7 @@ describe('MarketSandbox', () => {
     expect(buyers[0].paysOrReceived).toHaveTextContent('£5,333');
 
     expect(within(marketOutcome).getByTestId('total-bids')).toHaveTextContent(
-      '£25,000',
+      '£21,500',
     );
 
     expect(within(marketOutcome).getByTestId('total-offers')).toHaveTextContent(
@@ -851,7 +851,7 @@ describe('MarketSandbox', () => {
     );
 
     expect(within(marketOutcome).getByTestId('surplus')).toHaveTextContent(
-      '£14,000',
+      '£10,500',
     );
   });
 });

--- a/components/common/MarketSandbox/index.tsx
+++ b/components/common/MarketSandbox/index.tsx
@@ -19,6 +19,7 @@ import { MarketState } from '../../../types/market';
 import { HighlightedMapRegions } from '../../../types/map';
 import { isProjectEqual } from '../../../utils/walkthroughs';
 import { useProjectsContext } from '../../../context/ProjectsContext';
+import { RoleId } from '../../../types/roles';
 
 interface MarketSandboxProps {
   data: DemoData;
@@ -189,6 +190,20 @@ const getProjectsForTrader = (
   return project;
 };
 
+const getRoleId = (trader: DemoTrader): RoleId => {
+  const { role } = trader;
+
+  if (['buyer', 'investor'].includes(trader.role)) {
+    return 'buyer';
+  }
+
+  if (trader.role === 'seller') {
+    return 'seller';
+  }
+
+  throw new Error(`Trader has an invalid role: ${role}`);
+};
+
 const getHighlightedMapRegions = (
   traders: DemoTrader[],
 ): HighlightedMapRegions => {
@@ -198,11 +213,11 @@ const getHighlightedMapRegions = (
   };
 
   traders.forEach((trader) => {
-    if (trader.role === 'buyer') {
+    if (getRoleId(trader) === 'buyer') {
       regions.buyer.push(...trader.locations);
     }
 
-    if (trader.role === 'seller') {
+    if (getRoleId(trader) === 'seller') {
       regions.seller.push(...trader.locations);
     }
   }, regions);
@@ -231,7 +246,7 @@ export const MarketSandbox: NextPage<MarketSandboxProps> = ({
   );
 
   const hasMyProjects = !!myProjects.length;
-  const roleId = playableTrader?.role;
+  const roleId = playableTrader ? getRoleId(playableTrader) : undefined;
 
   const onSolveMarketClick = useCallback(async () => {
     if (!demoState) {

--- a/components/common/ProjectDetails/index.test.tsx
+++ b/components/common/ProjectDetails/index.test.tsx
@@ -24,6 +24,7 @@ const wrapper = ({ children }: WrapperProps) => (
     value={{
       setProjectCost,
       getProjectCost: jest.fn(),
+      getAcceptedProjectCost: jest.fn(),
     }}
   >
     {children}

--- a/constants/map.ts
+++ b/constants/map.ts
@@ -8,7 +8,7 @@ export const MAP_INDICES: { [key in string]: number } = {
   b1: 21,
   b2: 36,
   b3: 39,
-  i1: 26,
-  i2: 27,
-  i3: 28,
+  i1: 19,
+  i2: 25,
+  i3: 27,
 };

--- a/context/ProjectsContext.tsx
+++ b/context/ProjectsContext.tsx
@@ -9,10 +9,12 @@ import {
 } from 'react';
 import { isProjectEqual } from '@/utils/walkthroughs';
 import { Project } from '../types/project';
+import { getAdjustedCost } from '../utils/project';
 
 type ProjectsContextType = {
   getProjectCost: (project: Project) => number;
   setProjectCost: (project: Project, cost: number) => void;
+  getAcceptedProjectCost: (project: Project) => number;
 };
 
 type ProjectsState = {
@@ -85,12 +87,23 @@ export const ProjectsProvider: FunctionComponent<ProjectsProviderProps> = ({
     [state],
   );
 
+  const getAcceptedProjectCost = useCallback(
+    (project: Project): number => {
+      const cost = getProjectCost(project);
+      const accepted = project.accepted(cost);
+
+      return getAdjustedCost(cost, accepted);
+    },
+    [getProjectCost],
+  );
+
   const value = useMemo(
     (): ProjectsContextType => ({
       getProjectCost,
       setProjectCost,
+      getAcceptedProjectCost,
     }),
-    [getProjectCost, setProjectCost],
+    [getProjectCost, setProjectCost, getAcceptedProjectCost],
   );
 
   return (

--- a/types/demo.ts
+++ b/types/demo.ts
@@ -1,5 +1,3 @@
-import { RoleId } from './roles';
-
 export type DemoBid = {
   v: number;
   q: {
@@ -23,7 +21,7 @@ export type DemoState = {
 
 export type DemoTrader = {
   name: string;
-  role: RoleId;
+  role: string;
   locations: string[];
   enable_divisibility_element: boolean;
 };

--- a/types/project.ts
+++ b/types/project.ts
@@ -11,6 +11,7 @@ export interface Project {
   accepted: (value: number) => boolean | number;
   discountOrBonus: number;
   mapRegions?: string[];
+  groupId?: string;
 }
 
 // My projects require either a cost per credit or a highlighted map region, but

--- a/utils/project.ts
+++ b/utils/project.ts
@@ -1,0 +1,2 @@
+export const getAdjustedCost = (cost: number, accepted: boolean | number) =>
+  typeof accepted === 'number' ? (accepted / 100) * cost : cost;


### PR DESCRIPTION
Adds investor bidding support for the live demo:

<img width="1693" alt="image" src="https://user-images.githubusercontent.com/5636273/204586671-1a182fb1-4cd4-4871-9e87-654c2927728a.png">

The same mechanism can be applied to the relevant walkthroughs, they had some feedback on that, but that hasn't been included as part of this PR.