### PR TITLE
docs: add brief guide to adding more market sandbox scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,19 @@ After the installation is complete:
 
 Run `npm run dev` to start the development server on <http://localhost:3000>
 
-### What's Included
+## Table of contents
 
-- Project folder structure
-- Styling
-- Analytics
-- SEO setup
-- Sitemap
-- Prettier
-- env variables
-- Configuring walkthroughs
+- [Project folder structure](#project-folder-structure)
+- [Styling](#styling)
+- [Analytics](#page-analytics)
+- [SEO setup](#seo)
+- [Sitemap](#sitemap-generation)
+- [Prettier](#prettier)
+- [env variables](#env-variables)
+- [Configuring walkthroughs](#configuring-walkthroughs)
+- [Configuring the market sandbox](#configuring-the-market-sandbox)
 
-#### Project folder structure
+### Project folder structure
 
 - **_Pages directory_**: Since Next.js's router is file-system based, The folder _Pages_ is a Next-specific directory to place routes or pages. For each route, you will have a separate file, which is named as the route. For example the file _about.tsx_ in the pages directory will create the following route: <https://domain.com/about>. [See docs](https://nextjs.org/docs/routing/introduction) for more details.
 
@@ -39,34 +40,34 @@ Run `npm run dev` to start the development server on <http://localhost:3000>
 
 - **_Components directory_**: Contains React components which can be reused across multiple pages.
 
-#### Styling
+### Styling
 
 - [TailwindCSS](https://tailwindcss.com/docs/installation). A utility-first CSS framework with pre-configured classes to create an API for the projects design system.
 
-#### Page Analytics
+### Page Analytics
 
 We use [Fathom](https://usefathom.com/) for page analytics. Add the Fathom Analytics ID to the `next.config.js` file as an environmental variable. Use identifier/key `FATHOM_ANALYTICS_ID` as an env variable.
 
-#### SEO
+### SEO
 
 We setup default seo using the [next-seo package](https://github.com/garmeeh/next-seo). You can add your site name, site title and site url as environmental variables under the `next.config.js` file. See [the documentation](https://github.com/garmeeh/next-seo) on how to add seo bits on a per page basis.
 
-#### Sitemap Generation
+### Sitemap Generation
 
 We use the [next-sitemap package](https://www.npmjs.com/package/next-sitemap) to generate sitemap for different pages.
 
-#### Prettier
+### Prettier
 
 Prettier is a code formatter. It removes all original styling and ensures that all outputted code conforms to a consistent style.
 It'll do things like adding a semicolon to the end of every statement, or make sure your indentation is consistent. The `.prettierrc` file at the project's root is in charge of customising Prettier and how it works. We recommend that you should not touch this file, to keep this configuration consistent through out the period of this project. VScode also has a Prettier extension, see how to install it [here](https://www.educative.io/answers/how-to-set-up-prettier-and-automatic-formatting-on-vs-code).
 
-#### env variables
+### env variables
 
 Create a `.env.local` file in your root folder and add your sensitive environmental variables to this file. For less sensitive environmental variables (like site URL and title), add them under the `next.config.js` file.
 
 NB: Prefixing a env variable with `NEXT_PUBLIC_` exposes it to the browser. See [Next.js documentation](https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser).
 
-#### Configuring walkthroughs
+### Configuring walkthroughs
 
 The walkthroughs can be configured via the configuration files stored in the
 `data/walkthroughs` directory.
@@ -112,3 +113,9 @@ file for the relevant role (e.g. `data/walkthroughs/buyer/index.ts`). The
 scenario can be associated with an existing walkthrough, or an entirely new one.
 If using a new walkthrough this will show up automatically on the "How it works"
 index page.
+
+### Configuring the market sandbox
+
+To add more scenarios for the market sandbox drop JSON files into the
+[data/demo](./data/demo) folder. These scenarios will appear on the Market
+Sandbox index page.


### PR DESCRIPTION
A note on adding more market sandbox scenarios. Also tweaks the header levels and adds some anchor links to the table of contents (https://github.com/curiousways/marketdesign/blob/a71405355c76861101d7198cdb39a32e86b28511/README.md to see what that will look like).