### PR TITLE
fix: add button to go back to previous walkthrough

### DIFF
--- a/components/Walkthrough/index.tsx
+++ b/components/Walkthrough/index.tsx
@@ -1,7 +1,12 @@
 import { FC, MouseEvent, MouseEventHandler, useEffect, useState } from 'react';
 import { sentenceCase } from 'change-case';
+import { useRouter } from 'next/router';
 import { useWalkthroughContext } from '../../context/WalkthroughContext';
-import { getNextScenarioId, parseScenarioId } from '../../utils/walkthroughs';
+import {
+  createScenarioId,
+  getNextScenarioId,
+  parseScenarioId,
+} from '../../utils/walkthroughs';
 import { SideBar } from '../Sidebar';
 import { RoleId } from '../../types/roles';
 import { Market } from '../Market';
@@ -52,6 +57,7 @@ export const Walkthrough: FC = () => {
     isMarketSolving,
     wasSolvableStage,
   } = useWalkthroughContext();
+  const router = useRouter();
 
   const onSolveMarketClick: MouseEventHandler = (
     e: MouseEvent<HTMLElement>,
@@ -60,8 +66,9 @@ export const Walkthrough: FC = () => {
     goToNextMarketState();
   };
 
-  const { walkthroughIndex } = parseScenarioId(scenarioId);
+  const { walkthroughIndex, scenarioIndex } = parseScenarioId(scenarioId);
   const { isFormEnabled, allowDivision, showDivisibleInput } = scenario.options;
+  const hasPreviousWalkthrough = stage === 1 && scenarioIndex > 0;
 
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout>;
@@ -132,6 +139,18 @@ export const Walkthrough: FC = () => {
   };
 
   const onPreviousClick = () => {
+    if (hasPreviousWalkthrough) {
+      void router.replace(
+        `/how-it-works/${createScenarioId(
+          roleId,
+          walkthroughIndex,
+          scenarioIndex - 1,
+        )}`,
+      );
+
+      return;
+    }
+
     const hasPreviousSidebarContent = scenario.sidebarContent?.[stage - 1];
 
     // If the previous stage had no sidebar content and we have already passed
@@ -171,7 +190,7 @@ export const Walkthrough: FC = () => {
         title={walkthrough.title}
         subtitle={getWalkthroughTitle(roleId, walkthroughIndex)}
         hasNextPage={hasNextStage}
-        hasPreviousPage={hasPreviousStage}
+        hasPreviousPage={hasPreviousStage || hasPreviousWalkthrough}
         onNextClick={goToNextStage}
         onPreviousClick={onPreviousClick}
         showSolveMarketBtn={marketState === MarketState.solvable}


### PR DESCRIPTION
I'm opening this one as a draft as I'm not sure it really feels right. The feedback mentions:

> No back button to allow return to previous walkthrough.

It's not really clear if they expect it to go back to the start or the end of the previous walkthrough. This PR does the former, as that's far easier for one thing!

These walkthroughs are kind of designed to run in one direction and as we step through it we store various things in the local state. As each walkthrough loads a new page and resets the state once we progress to walkthrough 5.2, for example, we have lost all of the state for walkthrough 5.1, making going back to the end of walkthrough 5.1 a little tricky!

It does feel a bit odd like this though, as there are no clues that clicking the back button will take you that far back. So they probably meant they want it to go back to the last stage of the previous walkthrough, but it might be worth checking this before putting too much time into making it work!