### PR TITLE
fix: list sandbox walkthroughs under each category

### DIFF
--- a/pages/market-sandbox/index.tsx
+++ b/pages/market-sandbox/index.tsx
@@ -11,12 +11,11 @@ const groupByCategories = (demoFiles: DemoFile[]) => {
   const initialData: { [key in string]: DemoFile[] } = {};
 
   return demoFiles.reduce((acc, demoFile) => {
-    const categoryDescription = demoFile.data.categories.join(', ');
+    demoFile.data.categories.forEach((category) => {
+      acc[category] = [...(acc[category] ?? []), demoFile];
+    });
 
-    return {
-      ...acc,
-      [categoryDescription]: [...(acc[categoryDescription] ?? []), demoFile],
-    };
+    return acc;
   }, initialData);
 };
 


### PR DESCRIPTION
From the sandbox feedback:

> Each market example can belong to more than one Group. The Groups to which it belongs are listed in the "categories" key of the JSON string. That list needs to be parsed on reading and the market example should then appear under each Group in its "categories" list.

And I think this is what they mean:

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/5636273/206917397-5d7aca7b-f1c5-4d5d-93cc-5cce6631494b.png">
