### PR TITLE
fix: nav buttons

### DIFF
--- a/components/Column/index.tsx
+++ b/components/Column/index.tsx
@@ -1,41 +1,39 @@
-import { ReactNode } from 'react';
+import { FC, ReactNode } from 'react';
 
 import { classNames } from '@/utils/index';
 
-import { Button } from '@/components/Button';
+import { NavButton } from '@/components/NavButton';
 import { InlineTitle } from '@/components/InlineTitle/index';
 
-type Props = {
+type ColumnProps = {
   title?: string;
-  button?: boolean;
-  buttonLink?: string;
-  buttonText?: string;
+  button?: { link: string; text: string };
   titlebackground?: boolean;
   titleClass?: string;
   className?: string;
   children: ReactNode;
 };
 
-export const Column = ({
+export const Column: FC<ColumnProps> = ({
   title,
   button,
-  buttonLink,
-  buttonText,
   className,
   children,
   titlebackground,
   titleClass,
-}: Props) => {
+}: ColumnProps) => {
   return (
     <div className={classNames('max-w-[616px] space-y-10', className)}>
-      <InlineTitle
-        titleClass={titleClass ?? ''}
-        title={title ?? ''}
-        background={titlebackground}
-      />
+      {title && (
+        <InlineTitle
+          titleClass={titleClass}
+          title={title}
+          background={titlebackground}
+        />
+      )}
       {children}
 
-      {button && <Button text={buttonText ?? ''} link={buttonLink ?? ''} />}
+      {button && <NavButton text={button.text} link={button.link} />}
     </div>
   );
 };

--- a/components/InlineTitle/index.tsx
+++ b/components/InlineTitle/index.tsx
@@ -28,9 +28,7 @@ export const InlineTitle = ({
           />
         </svg>
       )}
-      <h2 className={classNames('heading-2', titleClass ?? '')}>
-        {title && title}
-      </h2>
+      <h2 className={classNames('heading-2', titleClass)}>{title}</h2>
     </div>
   );
 };

--- a/components/NavButton/index.test.tsx
+++ b/components/NavButton/index.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { NavButton } from './index';
+
+describe('NavButton', () => {
+  it('renders the given link', () => {
+    render(<NavButton link="/current-page" text="Click me" />);
+
+    const link = screen.getByRole('link');
+
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', '/current-page');
+  });
+});

--- a/components/NavButton/index.tsx
+++ b/components/NavButton/index.tsx
@@ -1,16 +1,19 @@
 import Link from 'next/link';
 import { FC } from 'react';
 
-type ButtonProps = {
+type NavButtonProps = {
   link: string;
   text: string;
 };
 
-export const Button: FC<ButtonProps> = ({ link, text }: ButtonProps) => {
+export const NavButton: FC<NavButtonProps> = ({
+  link,
+  text,
+}: NavButtonProps) => {
   return (
     <Link
       href={link}
-      className="border border-red text-red text-lg font-medium inline-flex items-center gap-x-2 py-1 px-2"
+      className="border border-red hover:bg-red transition-colors text-red hover:text-white text-lg font-medium inline-flex items-center gap-x-2 py-1 px-2"
     >
       <span>{text}</span>
 

--- a/pages/about-the-model.tsx
+++ b/pages/about-the-model.tsx
@@ -74,7 +74,7 @@ const About: NextPage = () => {
                   </p>
                 </div>
 
-                <Column button buttonLink="/" buttonText="Find out more">
+                <Column button={{ link: '/', text: 'Find out more' }}>
                   <ul className="space-y-3 list-disc list-inside text-lg">
                     <li>
                       Building Blocks: Participants, Projects, Credits, Costs &
@@ -94,9 +94,7 @@ const About: NextPage = () => {
           <div className="xl:flex gap-x-20">
             <Column
               title="Take a Test"
-              button
-              buttonText="Take the tour"
-              buttonLink="/how-it-works"
+              button={{ link: '/how-it-works', text: 'Take the tour' }}
             >
               <p>
                 Take a guided tour of a market scenario to gain a step-by-step
@@ -107,9 +105,7 @@ const About: NextPage = () => {
 
             <Column
               title="Fast Simulation Results"
-              button
-              buttonText="Take the tour"
-              buttonLink="/how-it-works"
+              button={{ link: '/how-it-works', text: 'Take the tour' }}
             >
               <p>
                 Take a guided tour of a market scenario to gain a step-by-step

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -75,11 +75,9 @@ const Home: NextPage = () => {
               <div className="relative pt-5 space-y-10">
                 <Column
                   title="Optimise the financial & environmental benefits"
-                  button
-                  buttonLink="/"
-                  buttonText="Find out more"
                   className="mt-5"
                   titlebackground
+                  button={{ link: '/about-the-model', text: 'Find out more' }}
                 >
                   <p>
                     The Exeter Lindsay market model applies robust and
@@ -104,10 +102,8 @@ const Home: NextPage = () => {
               {/* Take a tour */}
               <Column
                 title="Take a tour"
-                button
-                buttonLink="/"
-                buttonText="Find out more"
                 className="mt-20"
+                button={{ link: '/how-it-works', text: 'Take the tour' }}
               >
                 <p>
                   Take a guided tour of a market scenario to gain a step-by-step
@@ -147,10 +143,8 @@ const Home: NextPage = () => {
             {/* Give it a try */}
             <Column
               title="Give it a try"
-              button
-              buttonLink="/"
-              buttonText="Start trading"
               className="-mt-10 mb-28 max-w-[430px]"
+              button={{ link: '/market-sandbox', text: 'Start trading' }}
             >
               <p>
                 Get a feel for trading in markets based on Exeter Lindsay. We’ve


### PR DESCRIPTION
It looks like the various navigation buttons on the home page were broken while introducing the about page, in that they now all go to `/`. Probably some copy and pasting gone wrong there!

The about page is quite right either, in that it contains to links to `/how-it-works` and what looks like some duplicated text sections but maybe this is just some kind of placeholder so will leave this alone for now. Just came across this while looking at reusing a button component.