### PR TITLE
feat: hide submit/revise button once the market is solved

### DIFF
--- a/components/MarketSandbox/index.tsx
+++ b/components/MarketSandbox/index.tsx
@@ -393,6 +393,7 @@ export const MarketSandbox: NextPage<MarketSandboxProps> = ({
       <SideBar
         isFormEnabled={marketState === MarketState.pending}
         isFormReviseEnabled={marketState > MarketState.pending}
+        isFormSubmitHidden={marketState === MarketState.solved}
         showDetailsWidget={hasMyProjects}
         title={data.title}
         sidebarContent={data.description}

--- a/components/ProjectDetails/index.test.tsx
+++ b/components/ProjectDetails/index.test.tsx
@@ -287,6 +287,20 @@ describe('ProjectDetails', () => {
     expect(onFormRevise).not.toHaveBeenCalled();
   });
 
+  it('hides the submit button', () => {
+    render(
+      <ProjectDetails
+        isFormSubmitHidden
+        projects={[createProject()]}
+        onFormSubmit={jest.fn()}
+        roleId="buyer"
+      />,
+      { wrapper },
+    );
+
+    expect(screen.getByText('Submit')).toHaveClass('hidden');
+  });
+
   it('shows the selected map region', async () => {
     const region = 's1';
 

--- a/components/ProjectDetails/index.tsx
+++ b/components/ProjectDetails/index.tsx
@@ -17,6 +17,7 @@ type ProjectDetailsProps = {
   projects: Project[];
   isFormEnabled?: boolean;
   isFormReviseEnabled?: boolean;
+  isFormSubmitHidden?: boolean;
   hasFixedBids?: boolean;
   isDivisibleInputEnabled?: boolean;
   showDivisibleInput?: boolean;
@@ -68,6 +69,7 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
   projects,
   isFormEnabled,
   isFormReviseEnabled,
+  isFormSubmitHidden,
   hasFixedBids,
   isDivisibleInputEnabled,
   showDivisibleInput,
@@ -275,6 +277,7 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
                 isFormEnabled && !animatedInputName && animateNextSteps
                   ? 'animate-scale-large'
                   : '',
+                isFormSubmitHidden ? 'hidden' : '',
               )}
             >
               {isFormReviseEnabled ? 'Revise' : 'Submit'}

--- a/components/Sidebar/index.tsx
+++ b/components/Sidebar/index.tsx
@@ -22,6 +22,7 @@ type SidebarProps = {
   sidebarContent?: ReactNode;
   isFormEnabled?: boolean;
   isFormReviseEnabled?: boolean;
+  isFormSubmitHidden?: boolean;
   animateNextSteps?: boolean;
   hasFixedBids?: boolean;
   isDivisibleInputEnabled?: boolean;
@@ -45,6 +46,7 @@ export const SideBar: FC<SidebarProps> = ({
   sidebarContent,
   isFormEnabled,
   isFormReviseEnabled,
+  isFormSubmitHidden,
   animateNextSteps,
   hasFixedBids,
   isDivisibleInputEnabled,
@@ -64,6 +66,7 @@ export const SideBar: FC<SidebarProps> = ({
           <ProjectDetails
             isFormEnabled={isFormEnabled}
             isFormReviseEnabled={isFormReviseEnabled}
+            isFormSubmitHidden={isFormSubmitHidden}
             hasFixedBids={hasFixedBids}
             isDivisibleInputEnabled={isDivisibleInputEnabled}
             showDivisibleInput={showDivisibleInput}

--- a/components/Walkthrough/index.tsx
+++ b/components/Walkthrough/index.tsx
@@ -179,6 +179,7 @@ export const Walkthrough: FC = () => {
         onSolveMarketClick={onSolveMarketClick}
         sidebarContent={scenario.sidebarContent?.[stage]}
         isFormEnabled={isFormEnabled}
+        isFormSubmitHidden={marketState === MarketState.solved}
         isDivisibleInputEnabled={isFormEnabled && allowDivision}
         showDivisibleInput={showDivisibleInput}
         onFormSubmit={onFormSubmit}


### PR DESCRIPTION
From the sandbox feedback:

> The revise bid in the My Project box should no longer be visible or at least not be active once the market has played out.


https://user-images.githubusercontent.com/5636273/206922087-865739fc-17b5-4211-8e7d-6ec72e21c443.mov

