### PR TITLE
fix: address the situation when all projects in a group win

### DIFF
--- a/components/MarketParticipant/index.tsx
+++ b/components/MarketParticipant/index.tsx
@@ -306,10 +306,11 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
 }: MarketParticipantProps) => {
   const isBuyer = projectRoleId === 'buyer';
 
+  const hasGroupedCost = totalCost !== projectCost;
   const showLoserStyles = isLoser && showWinners;
   const isNotAccepted = showWinners && !accepted;
-  const showResults = !isDivisible || isLastGroupedProject;
-  const shiftResults = isDivisible && !!(isGroupedProject && showResults);
+  const showResults = !hasGroupedCost || isLastGroupedProject;
+  const shiftResults = hasGroupedCost && !!(isGroupedProject && showResults);
 
   const rowAnimation = useRowAnimation(
     showLoserStyles,

--- a/components/MarketParticipantList/index.test.tsx
+++ b/components/MarketParticipantList/index.test.tsx
@@ -395,7 +395,57 @@ describe('MarketParticipantList', () => {
     expect(buyers[1].paysOrReceived).toHaveTextContent('£16,000');
   });
 
-  it('does not group the results for non-divisible projects', () => {
+  it('does not group the results when not all projects in a group were accepted', () => {
+    render(
+      <MarketParticipantList
+        myProjects={[]}
+        losingProjects={[]}
+        buyerProjects={[
+          {
+            title: 'Seller',
+            subtitle: 'Field 1',
+            cost: 10000,
+            products: { biodiversity: 1, nutrients: 0 },
+            accepted: () => true,
+            discountOrBonus: 2500,
+            groupId: '1',
+          },
+          {
+            title: 'Seller',
+            subtitle: 'Field 2',
+            cost: 18000,
+            products: { biodiversity: 0, nutrients: 2 },
+            accepted: () => false,
+            discountOrBonus: 2500,
+            groupId: '1',
+          },
+        ]}
+        sellerProjects={[]}
+        roleId="seller"
+        showCosts
+        showSurpluses
+        showWinners
+      />,
+      { wrapper },
+    );
+
+    const { buyers, sellers } = getMarketParticipants();
+
+    expect(buyers).toHaveLength(2);
+    expect(sellers).toHaveLength(0);
+
+    expect(buyers[0].title).toHaveTextContent(/^SellerField 1$/);
+    expect(buyers[0].bidOrOffer).toHaveTextContent('£10,000');
+    expect(buyers[0].discountOrBonus).toHaveStyle({ opacity: 0 });
+    expect(buyers[0].paysOrReceived).toHaveStyle({ opacity: 0 });
+
+    expect(buyers[1].title).toHaveTextContent(/^Field 2$/);
+    expect(buyers[1].bidOrOffer).toHaveTextContent('£18,000');
+    expect(buyers[1].discountOrBonus).toHaveTextContent('£2,500');
+    expect(buyers[1].paysOrReceived).toHaveTextContent('£15,500');
+  });
+
+  it('group the results when all projects in a group were accepted', () => {
     render(
       <MarketParticipantList
         myProjects={[]}
@@ -442,6 +492,6 @@ describe('MarketParticipantList', () => {
     expect(buyers[1].title).toHaveTextContent(/^Field 2$/);
     expect(buyers[1].bidOrOffer).toHaveTextContent('£18,000');
     expect(buyers[1].discountOrBonus).toHaveTextContent('£2,500');
-    expect(buyers[1].paysOrReceived).toHaveTextContent('£15,500');
+    expect(buyers[1].paysOrReceived).toHaveTextContent('£25,500');
   });
 });

--- a/components/MarketParticipantList/index.tsx
+++ b/components/MarketParticipantList/index.tsx
@@ -80,20 +80,28 @@ export const MarketParticipantList: FC<MarketParticipantListProps> = ({
       {sortedProjects.map((project) => {
         const groupedProjects = getGroupedProjects(sortedProjects, project);
         const isGroupedProject = groupedProjects.length > 1;
+
         const isFirstGroupedProject = groupedProjects.indexOf(project) === 0;
         const isLastGroupedProject =
           groupedProjects.indexOf(project) === groupedProjects.length - 1;
 
         const projectCost = getProjectCost(project, true);
 
+        const isDivisible = !!project.costPerCredit;
+        const allGroupedProjectsWon =
+          groupedProjects.length > 1 &&
+          groupedProjects.every((groupedProject) =>
+            groupedProject.accepted(getProjectCost(groupedProject)),
+          );
+
         // The total cost for all projects in a group is needed for the case
         // where a project comprises multple "sub-projects" (e.g. investor bidding).
-        const isDivisible = !!project.costPerCredit;
-        const totalCost = isDivisible
-          ? groupedProjects
-              .map(getAcceptedProjectCost)
-              .reduce((a, b) => a + b, 0)
-          : projectCost;
+        const totalCost =
+          isDivisible || allGroupedProjectsWon
+            ? groupedProjects
+                .map(getAcceptedProjectCost)
+                .reduce((a, b) => a + b, 0)
+            : projectCost;
 
         return (
           <li key={JSON.stringify(project)}>


### PR DESCRIPTION
From the seller feedback:

> WalkthruS5.1 presents the case where a seller had two fields and submits bids for each. 4 outcomes are possible. (1) Neither field wins, (2) Field 1 wins and Field 2 loses, (3) FieId 1 loses and Field 1 wins, (4) Both fields win. As per all bids and offers the API solver returns only one Bonus and one Payment receipt for that seller. If only Field 1 wins then that bonus and receipt should align in that bid strip with "Not accepted" in the other. Likewise if only Field 2 wins, then those amounts should appear in that bid strip. That logic is working fine. If both fields win (as will happen if you put in low offers for both) then the bonus and received amount should be placed along the centre of the strip. At the moment this is replicated in the Field 1 strip and the Field 2 strip.

Those last two sentences being the bit that wasn't working.

https://user-images.githubusercontent.com/5636273/207075739-cfd307b8-cabe-47cb-b655-c950cc62ca4a.mov