### PR TITLE
feat: have a go at labelling map regions

### DIFF
--- a/components/Map/index.test.tsx
+++ b/components/Map/index.test.tsx
@@ -19,7 +19,9 @@ describe('Map', () => {
   it('highlights a buyer region by index', () => {
     const mapRegion = 'b1';
 
-    render(<Map highlightedMapRegions={{ buyer: [mapRegion] }} />);
+    render(
+      <Map highlightedMapRegions={{ buyer: [{ regionKey: mapRegion }] }} />,
+    );
 
     const filledPaths = getFilledPaths();
 
@@ -33,7 +35,9 @@ describe('Map', () => {
   it('highlights a seller region by index', () => {
     const mapRegion = 's1';
 
-    render(<Map highlightedMapRegions={{ seller: [mapRegion] }} />);
+    render(
+      <Map highlightedMapRegions={{ seller: [{ regionKey: mapRegion }] }} />,
+    );
 
     const filledPaths = getFilledPaths();
 
@@ -46,7 +50,12 @@ describe('Map', () => {
 
   it('highlights a some regions by mapped region key', () => {
     render(
-      <Map highlightedMapRegions={{ seller: ['s1'], buyer: ['b1', 'b2'] }} />,
+      <Map
+        highlightedMapRegions={{
+          seller: [{ regionKey: 's1' }],
+          buyer: [{ regionKey: 'b1' }, { regionKey: 'b2' }],
+        }}
+      />,
     );
 
     const filledPaths = getFilledPaths();
@@ -67,7 +76,7 @@ describe('Map', () => {
 
     render(
       <Map
-        highlightedMapRegions={{ seller: ['s1'] }}
+        highlightedMapRegions={{ seller: [{ regionKey: 's1' }] }}
         onMapRegionClick={onClick}
       />,
     );

--- a/components/MapRegion/index.test.tsx
+++ b/components/MapRegion/index.test.tsx
@@ -30,7 +30,12 @@ describe('MapRegion', () => {
     const onClick = jest.fn();
 
     render(
-      <MapRegion roleId="buyer" index={12} region="b1" onClick={onClick} />,
+      <MapRegion
+        roleId="buyer"
+        index={12}
+        region={{ regionKey: 'b1' }}
+        onClick={onClick}
+      />,
     );
 
     const path = screen.getByTestId('map-region');
@@ -74,7 +79,13 @@ describe('MapRegion', () => {
   it.each(['woodland', 'wetland'])(
     'renders a region filled with the %s icon',
     (iconType) => {
-      render(<MapRegion index={21} roleId="buyer" region={`s1-${iconType}`} />);
+      render(
+        <MapRegion
+          index={21}
+          roleId="buyer"
+          region={{ regionKey: `s1-${iconType}` }}
+        />,
+      );
 
       expect(screen.getByTestId('map-region-icon')).toMatchSnapshot();
     },
@@ -89,7 +100,7 @@ describe('MapRegion', () => {
           size={50}
           index={21}
           roleId="buyer"
-          region={`s1-${iconType}`}
+          region={{ regionKey: `s1-${iconType}` }}
         />,
       );
 

--- a/components/MapRegion/index.tsx
+++ b/components/MapRegion/index.tsx
@@ -9,10 +9,11 @@ import { RoleId } from '../../types/roles';
 import { classNames } from '../../utils';
 import oakTree from '../../public/assets/images/oak-tree.png';
 import swamp from '../../public/assets/images/swamp.png';
+import { HighlightedMapRegion } from '../../types/map';
 
 type MapRegionProps = {
   index: number;
-  region?: string;
+  region?: HighlightedMapRegion;
   size?: number;
   roleId?: RoleId;
   onClick?: (region: string, index: number) => void;
@@ -128,7 +129,7 @@ export const MapRegion: FunctionComponent<MapRegionProps> = ({
   const [boundingBox, setBoundingBox] = useState<DOMRect>();
 
   // Split the possible icon type from the given region.
-  const [finalRegion, iconType] = (region ?? '').split('-');
+  const [finalRegion, iconType] = (region?.regionKey ?? '').split('-');
 
   useEffect(() => {
     if (!ref.current || pathOnly) {
@@ -162,6 +163,7 @@ export const MapRegion: FunctionComponent<MapRegionProps> = ({
         stroke="black"
         className={classNames(isClickable ? 'cursor-pointer' : '')}
         onClick={handleClick}
+        data-label={region?.label}
       />
       {iconType && (
         <g data-testid="map-region-icon">

--- a/components/MarketSandbox/index.tsx
+++ b/components/MarketSandbox/index.tsx
@@ -17,7 +17,7 @@ import { Market } from '../Market';
 import { Bid, Result } from '../../types/result';
 import { Project } from '../../types/project';
 import { MarketState } from '../../types/market';
-import { HighlightedMapRegions } from '../../types/map';
+import { HighlightedMapRegion, HighlightedMapRegions } from '../../types/map';
 import { isProjectEqual } from '../../utils/project';
 import { useProjectsContext } from '../../context/ProjectsContext';
 import { RoleId } from '../../types/roles';
@@ -288,18 +288,31 @@ const getRoleId = (trader: DemoTrader): RoleId => {
 const getHighlightedMapRegions = (
   traders: DemoTrader[],
 ): HighlightedMapRegions => {
-  const regions: { buyer: string[]; seller: string[] } = {
+  const regions: {
+    buyer: HighlightedMapRegion[];
+    seller: HighlightedMapRegion[];
+  } = {
     buyer: [],
     seller: [],
   };
 
   traders.forEach((trader) => {
     if (getRoleId(trader) === 'buyer') {
-      regions.buyer.push(...trader.locations);
+      regions.buyer.push(
+        ...trader.locations.map((regionKey) => ({
+          regionKey,
+          label: trader.name,
+        })),
+      );
     }
 
     if (getRoleId(trader) === 'seller') {
-      regions.seller.push(...trader.locations);
+      regions.seller.push(
+        ...trader.locations.map((regionKey) => ({
+          regionKey,
+          label: trader.name,
+        })),
+      );
     }
   }, regions);
 

--- a/components/ProjectDetails/index.tsx
+++ b/components/ProjectDetails/index.tsx
@@ -168,13 +168,13 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
                   {/* Selected map region(s) */}
                   {!project.costPerCredit && project.mapRegions && (
                     <div className="flex">
-                      {project.mapRegions.map((mapRegion, _index, arr) => (
+                      {project.mapRegions.map((regionKey, _index, arr) => (
                         <MapRegion
                           isSmall
-                          key={mapRegion}
-                          region={mapRegion}
+                          key={regionKey}
+                          region={{ regionKey }}
                           size={MAP_REGION_ICON_SIZE / arr.length}
-                          index={MAP_INDICES[mapRegion.split('-')[0]]}
+                          index={MAP_INDICES[regionKey.split('-')[0]]}
                           roleId={roleId}
                         />
                       ))}

--- a/data/walkthroughs/scenarios/buyers/1.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/1.1/index.ts
@@ -74,7 +74,7 @@ export const getBuyerScenario1_1: GetWalkthroughScenario = (stage: number) => ({
     showDetailsWidget: stage >= 2,
     showMaps: true,
     highlightedMapRegions: {
-      buyer: stage >= 2 ? [HIGHLIGHTED_MAP_REGION] : undefined,
+      buyer: stage >= 2 ? [{ regionKey: HIGHLIGHTED_MAP_REGION }] : undefined,
     },
     showParticipants: stage >= 3,
   },

--- a/data/walkthroughs/scenarios/buyers/2.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/2.1/index.ts
@@ -68,7 +68,7 @@ export const getBuyerScenario2_1: GetWalkthroughScenario = (stage: number) => ({
     showDetailsWidget: stage >= 2,
     showMaps: true,
     highlightedMapRegions: {
-      buyer: stage >= 2 ? [HIGHLIGHTED_MAP_REGION] : undefined,
+      buyer: stage >= 2 ? [{ regionKey: HIGHLIGHTED_MAP_REGION }] : undefined,
     },
     showParticipants: stage >= 3,
   },

--- a/data/walkthroughs/scenarios/buyers/3.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/3.1/index.ts
@@ -68,7 +68,7 @@ export const getBuyerScenario3_1: GetWalkthroughScenario = (stage: number) => ({
     showDetailsWidget: stage >= 2,
     showMaps: true,
     highlightedMapRegions: {
-      buyer: stage >= 2 ? [HIGHLIGHTED_MAP_REGION] : undefined,
+      buyer: stage >= 2 ? [{ regionKey: HIGHLIGHTED_MAP_REGION }] : undefined,
     },
     showParticipants: stage >= 3,
   },

--- a/data/walkthroughs/scenarios/buyers/4.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/4.1/index.ts
@@ -75,7 +75,7 @@ export const getBuyerScenario4_1: GetWalkthroughScenario = (stage: number) => ({
     showDivisibleInput: true,
     showMaps: true,
     highlightedMapRegions: {
-      buyer: stage >= 2 ? [HIGHLIGHTED_MAP_REGION] : undefined,
+      buyer: stage >= 2 ? [{ regionKey: HIGHLIGHTED_MAP_REGION }] : undefined,
     },
     showParticipants: stage >= 3,
   },

--- a/data/walkthroughs/scenarios/generic/1.1/index.ts
+++ b/data/walkthroughs/scenarios/generic/1.1/index.ts
@@ -208,14 +208,14 @@ const getHighlightedMapRegions = (
 ): HighlightedMapRegions | undefined => {
   if (stage === 3) {
     return {
-      seller: ['s3'],
+      seller: [{ regionKey: 's3' }],
     };
   }
 
   if (stage === 5) {
     return {
-      seller: ['s3'],
-      buyer: ['b2'],
+      seller: [{ regionKey: 's3' }],
+      buyer: [{ regionKey: 'b2' }],
     };
   }
 };

--- a/data/walkthroughs/scenarios/sellers/1.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/1.1/index.ts
@@ -74,7 +74,7 @@ export const getSellerScenario1_1: GetWalkthroughScenario = (
     showDetailsWidget: stage >= 2,
     showMaps: true,
     highlightedMapRegions: {
-      seller: stage >= 2 ? [HIGHLIGHTED_MAP_REGION] : undefined,
+      seller: stage >= 2 ? [{ regionKey: HIGHLIGHTED_MAP_REGION }] : undefined,
     },
     showParticipants: stage >= 3,
   },

--- a/data/walkthroughs/scenarios/sellers/2.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/2.1/index.ts
@@ -70,7 +70,7 @@ export const getSellerScenario2_1: GetWalkthroughScenario = (
     showDetailsWidget: stage >= 2,
     showMaps: true,
     highlightedMapRegions: {
-      seller: stage >= 2 ? [HIGHLIGHTED_MAP_REGION] : undefined,
+      seller: stage >= 2 ? [{ regionKey: HIGHLIGHTED_MAP_REGION }] : undefined,
     },
     showParticipants: stage >= 3,
   },

--- a/data/walkthroughs/scenarios/sellers/3.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/3.1/index.ts
@@ -70,7 +70,7 @@ export const getSellerScenario3_1: GetWalkthroughScenario = (
     showDetailsWidget: stage >= 2,
     showMaps: true,
     highlightedMapRegions: {
-      seller: stage >= 2 ? [HIGHLIGHTED_MAP_REGION] : undefined,
+      seller: stage >= 2 ? [{ regionKey: HIGHLIGHTED_MAP_REGION }] : undefined,
     },
     showParticipants: stage >= 3,
   },

--- a/data/walkthroughs/scenarios/sellers/4.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/4.1/index.ts
@@ -11,11 +11,11 @@ const getHighlightedMapRegions = (
   stage: number,
 ): HighlightedMapRegions | undefined => {
   if (stage === 2) {
-    return { seller: ['s1-woodland'] };
+    return { seller: [{ regionKey: 's1-woodland' }] };
   }
 
   if (stage === 3) {
-    return { seller: ['s1-wetland'] };
+    return { seller: [{ regionKey: 's1-wetland' }] };
   }
 };
 

--- a/data/walkthroughs/scenarios/sellers/5.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/5.1/index.ts
@@ -69,7 +69,10 @@ export const getSellerScenario5_1: GetWalkthroughScenario = (
     highlightedMapRegions: {
       seller:
         stage >= 2
-          ? [HIGHLIGHTED_MAP_REGION_ONE, HIGHLIGHTED_MAP_REGION_TWO]
+          ? [
+              { regionKey: HIGHLIGHTED_MAP_REGION_ONE },
+              { regionKey: HIGHLIGHTED_MAP_REGION_TWO },
+            ]
           : undefined,
     },
     showParticipants: stage >= 3,

--- a/types/map.ts
+++ b/types/map.ts
@@ -1,5 +1,10 @@
 import { RoleId } from './roles';
 
+export type HighlightedMapRegion = {
+  label?: string;
+  regionKey: string;
+};
+
 export type HighlightedMapRegions = Partial<{
-  [key in RoleId]: string[];
+  [key in RoleId]: HighlightedMapRegion[];
 }>;


### PR DESCRIPTION
Opening this as a draft for the sake of discussion. From the sandbox feedback:

> Player names need to appear over their field on the map

This isn't going to be all that easy to do in a way that's likely to be acceptable within an SVG where the regions are all different shapes and sizes. This PR adds those labels, centred over each region, but due to the unusual shapes the placement of these labels might feel quite inconsistent. For example, this is what it looks like for a couple of examples:

<img width="865" alt="image" src="https://user-images.githubusercontent.com/5636273/207093543-c010c313-8443-47d0-bcca-e6d690ee753e.png">

<img width="871" alt="image" src="https://user-images.githubusercontent.com/5636273/207093818-3ad93266-45f2-4cd1-8dec-3e8f42e2cdd6.png">

As we can see, some of them look better than others, as the label happens to sit over the main body of the highlighted region. For others they're off to the side. Before spending more hours on this it might be worth questioning how important it is? Or, if something like this is acceptable then we can go ahead and merge!