### PR TITLE
feat: add tooltip with trader name to the map

### DIFF
--- a/components/Map/index.test.tsx
+++ b/components/Map/index.test.tsx
@@ -19,7 +19,11 @@ describe('Map', () => {
   it('highlights a buyer region by index', () => {
     const mapRegion = 'b1';
 
-    render(<Map highlightedMapRegions={{ buyer: [mapRegion] }} />);
+    render(
+      <Map
+        highlightedMapRegions={[{ roleId: 'buyer', regions: [mapRegion] }]}
+      />,
+    );
 
     const filledPaths = getFilledPaths();
 
@@ -33,7 +37,11 @@ describe('Map', () => {
   it('highlights a seller region by index', () => {
     const mapRegion = 's1';
 
-    render(<Map highlightedMapRegions={{ seller: [mapRegion] }} />);
+    render(
+      <Map
+        highlightedMapRegions={[{ roleId: 'seller', regions: [mapRegion] }]}
+      />,
+    );
 
     const filledPaths = getFilledPaths();
 
@@ -46,7 +54,12 @@ describe('Map', () => {
 
   it('highlights a some regions by mapped region key', () => {
     render(
-      <Map highlightedMapRegions={{ seller: ['s1'], buyer: ['b1', 'b2'] }} />,
+      <Map
+        highlightedMapRegions={[
+          { roleId: 'seller', regions: ['s1'] },
+          { roleId: 'buyer', regions: ['b1', 'b2'] },
+        ]}
+      />,
     );
 
     const filledPaths = getFilledPaths();
@@ -67,7 +80,7 @@ describe('Map', () => {
 
     render(
       <Map
-        highlightedMapRegions={{ seller: ['s1'] }}
+        highlightedMapRegions={[{ roleId: 'seller', regions: ['s1'] }]}
         onMapRegionClick={onClick}
       />,
     );

--- a/components/Map/index.tsx
+++ b/components/Map/index.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'react';
-import { HighlightedMapRegions } from '@/types/map';
+import { HighlightedMapRegion } from '@/types/map';
 import { MAP_REGION_PATHS, MapRegion } from '../MapRegion';
 import {
   MAP_INDICES,
@@ -9,7 +9,7 @@ import {
 } from '../../constants/map';
 
 type Props = {
-  highlightedMapRegions?: HighlightedMapRegions;
+  highlightedMapRegions?: HighlightedMapRegion[];
   investorRegions?: string[];
   onMapRegionClick?: (region: string) => void;
 };
@@ -99,19 +99,20 @@ export const Map: FunctionComponent<Props> = ({
         {MAP_REGION_PATHS.map((path, index) => {
           let matchedRoleId;
           let matchedRegion;
+          let matchedLabel;
 
-          Object.entries(highlightedMapRegions ?? {}).find(
-            ([roleId, regions = []]) =>
-              regions.some((region) => {
-                if (MAP_INDICES[region.split('-')[0]] !== index) {
-                  return false;
-                }
+          highlightedMapRegions?.find(({ roleId, regions, label }) =>
+            regions.some((region) => {
+              if (MAP_INDICES[region.split('-')[0]] !== index) {
+                return false;
+              }
 
-                matchedRegion = region;
-                matchedRoleId = roleId;
+              matchedRegion = region;
+              matchedRoleId = roleId;
+              matchedLabel = label;
 
-                return true;
-              }),
+              return true;
+            }),
           );
 
           return (
@@ -122,6 +123,7 @@ export const Map: FunctionComponent<Props> = ({
               region={matchedRegion}
               roleId={matchedRoleId}
               onClick={onMapRegionClick}
+              label={matchedLabel}
             />
           );
         })}

--- a/components/MapRegion/index.tsx
+++ b/components/MapRegion/index.tsx
@@ -18,6 +18,7 @@ type MapRegionProps = {
   onClick?: (region: string) => void;
   pathOnly?: boolean;
   isSmall?: boolean;
+  label?: string;
 };
 
 const ICONS: { [x in string]: StaticImageData } = {
@@ -123,6 +124,7 @@ export const MapRegion: FunctionComponent<MapRegionProps> = ({
   onClick,
   pathOnly,
   isSmall,
+  label,
 }: MapRegionProps) => {
   const ref = useRef<SVGPathElement>(null);
   const [boundingBox, setBoundingBox] = useState<DOMRect>();
@@ -162,7 +164,9 @@ export const MapRegion: FunctionComponent<MapRegionProps> = ({
         stroke="black"
         className={classNames(isClickable ? 'cursor-pointer' : '')}
         onClick={handleClick}
-      />
+      >
+        {label && <title>{label}</title>}
+      </path>
       {iconType && (
         <g data-testid="map-region-icon">
           <path

--- a/components/Market/index.tsx
+++ b/components/Market/index.tsx
@@ -6,7 +6,7 @@ import { MarketBackgroundRight } from '../../icons/MarketBackground';
 import { MarketScenario } from '../MarketScenario';
 import { Project } from '../../types/project';
 import { RoleId } from '../../types/roles';
-import { HighlightedMapRegions } from '../../types/map';
+import { HighlightedMapRegion } from '../../types/map';
 
 type MarketProps = {
   myProjects: Project[];
@@ -20,7 +20,7 @@ type MarketProps = {
   isMarketSolved: boolean;
   showParticipants: boolean;
   showMap?: boolean;
-  highlightedMapRegions?: HighlightedMapRegions;
+  highlightedMapRegions?: HighlightedMapRegion[];
   investorRegions?: string[];
   onMapRegionClick?: (region: string) => void;
   link?: {

--- a/components/MarketSandbox/index.tsx
+++ b/components/MarketSandbox/index.tsx
@@ -17,7 +17,7 @@ import { Market } from '../Market';
 import { Bid, Result } from '../../types/result';
 import { Project } from '../../types/project';
 import { MarketState } from '../../types/market';
-import { HighlightedMapRegions } from '../../types/map';
+import { HighlightedMapRegion } from '../../types/map';
 import { isProjectEqual } from '../../utils/project';
 import { useProjectsContext } from '../../context/ProjectsContext';
 import { RoleId } from '../../types/roles';
@@ -305,19 +305,24 @@ const getRoleId = (trader: DemoTrader): RoleId => {
 
 const getHighlightedMapRegions = (
   traders: DemoTrader[],
-): HighlightedMapRegions => {
-  const regions: { buyer: string[]; seller: string[] } = {
-    buyer: [],
-    seller: [],
-  };
+): HighlightedMapRegion[] => {
+  const regions: HighlightedMapRegion[] = [];
 
   traders.forEach((trader) => {
     if (trader.role === 'buyer') {
-      regions.buyer.push(...trader.locations);
+      regions.push({
+        roleId: 'buyer',
+        regions: trader.locations,
+        label: trader.name,
+      });
     }
 
     if (trader.role === 'seller') {
-      regions.seller.push(...trader.locations);
+      regions.push({
+        roleId: 'seller',
+        regions: trader.locations,
+        label: trader.name,
+      });
     }
   }, regions);
 

--- a/components/MarketScenario/index.tsx
+++ b/components/MarketScenario/index.tsx
@@ -8,7 +8,7 @@ import { MarketParticipantList } from '../MarketParticipantList';
 import { MarketOutcome } from '../MarketOutcome';
 import { Project } from '../../types/project';
 import { useProjectsContext } from '../../context/ProjectsContext';
-import { HighlightedMapRegions } from '../../types/map';
+import { HighlightedMapRegion } from '../../types/map';
 import { Map } from '../Map';
 import { getGroupedProjects } from '../../utils/project';
 import { MarketParticipant } from '../MarketParticipant';
@@ -25,7 +25,7 @@ type MarketScenarioProps = {
   showCosts: boolean;
   showParticipants: boolean;
   showMap?: boolean;
-  highlightedMapRegions?: HighlightedMapRegions;
+  highlightedMapRegions?: HighlightedMapRegion[];
   investorRegions?: string[];
   onMapRegionClick?: (region: string) => void;
   link?: {

--- a/components/Walkthrough/index.tsx
+++ b/components/Walkthrough/index.tsx
@@ -1,12 +1,18 @@
 import { FC, MouseEvent, MouseEventHandler, useEffect, useState } from 'react';
 import { sentenceCase } from 'change-case';
 import { useWalkthroughContext } from '../../context/WalkthroughContext';
-import { getNextScenarioId, parseScenarioId } from '../../utils/walkthroughs';
+import {
+  getNextScenarioId,
+  isValidRoleId,
+  parseScenarioId,
+} from '../../utils/walkthroughs';
 import { SideBar } from '../Sidebar';
 import { RoleId } from '../../types/roles';
 import { Market } from '../Market';
 import { MarketState } from '../../types/market';
 import { MainContainer } from '../MainContainer';
+import { HighlightedMapRegion } from '../../types/map';
+import { WalkthroughScenario } from '../../types/walkthrough';
 
 const MARKET_SOLVING_TIMEOUT = 4000;
 const MARKET_SOLVING_STAGES = 5;
@@ -31,6 +37,20 @@ const getOverlayText = (marketState: MarketState) => {
   if (marketState === MarketState.calculating_final_payments) {
     return 'Calculating Final Payments';
   }
+};
+
+const getHighlightedMapRegions = (scenario: WalkthroughScenario) => {
+  const highlightedMapRegions: HighlightedMapRegion[] = [];
+
+  Object.entries(scenario.options.highlightedMapRegions ?? {}).forEach(
+    ([roleId, regions]) => {
+      if (isValidRoleId(roleId) && regions?.length) {
+        highlightedMapRegions.push({ regions, roleId });
+      }
+    },
+  );
+
+  return highlightedMapRegions;
 };
 
 export const Walkthrough: FC = () => {
@@ -210,7 +230,7 @@ export const Walkthrough: FC = () => {
         }
         showParticipants={scenario.options.showParticipants}
         showMap={scenario.options.showMaps}
-        highlightedMapRegions={scenario.options.highlightedMapRegions}
+        highlightedMapRegions={getHighlightedMapRegions(scenario)}
         loadingOverlayText={getOverlayText(marketState)}
         loadingBar={{
           progress: loadingBarProgress,

--- a/data/walkthroughs/scenarios/generic/1.1/index.ts
+++ b/data/walkthroughs/scenarios/generic/1.1/index.ts
@@ -1,8 +1,8 @@
 import {
   GetWalkthroughScenario,
+  WalkthroughHighlightedMapRegions,
   WalkthroughScenario,
 } from '@/types/walkthrough';
-import { HighlightedMapRegions } from '../../../../../types/map';
 import { MarketState } from '../../../../../types/market';
 import { Project } from '../../../../../types/project';
 import { sidebarContent1 } from './sidebar-content/1';
@@ -207,7 +207,7 @@ const getMarketState = (stage: number): MarketState => {
 
 const getHighlightedMapRegions = (
   stage: number,
-): HighlightedMapRegions | undefined => {
+): WalkthroughHighlightedMapRegions | undefined => {
   if (stage === 3) {
     return {
       seller: ['s1'],

--- a/data/walkthroughs/scenarios/sellers/4.1/index.ts
+++ b/data/walkthroughs/scenarios/sellers/4.1/index.ts
@@ -1,15 +1,17 @@
-import { GetWalkthroughScenario } from '@/types/walkthrough';
+import {
+  GetWalkthroughScenario,
+  WalkthroughHighlightedMapRegions,
+} from '@/types/walkthrough';
 import { sidebarContentStage1 } from './sidebar-content/1';
 import { sidebarContentStage2 } from './sidebar-content/2';
 import { sidebarContentStage3 } from './sidebar-content/3';
 import { sidebarContentStage12 } from './sidebar-content/12';
 import { sidebarContentStage4 } from './sidebar-content/4';
 import { sidebarContentStage5 } from './sidebar-content/5';
-import { HighlightedMapRegions } from '../../../../../types/map';
 
 const getHighlightedMapRegions = (
   stage: number,
-): HighlightedMapRegions | undefined => {
+): WalkthroughHighlightedMapRegions | undefined => {
   if (stage === 2) {
     return { seller: ['s1-woodland'] };
   }

--- a/types/map.ts
+++ b/types/map.ts
@@ -1,5 +1,7 @@
 import { RoleId } from './roles';
 
-export type HighlightedMapRegions = Partial<{
-  [key in RoleId]: string[];
-}>;
+export type HighlightedMapRegion = {
+  roleId: RoleId;
+  regions: string[];
+  label?: string;
+};

--- a/types/walkthrough.ts
+++ b/types/walkthrough.ts
@@ -1,7 +1,10 @@
-import { HighlightedMapRegions } from './map';
 import { MarketState } from './market';
 import { MyProject, Project } from './project';
 import { RoleId } from './roles';
+
+export type WalkthroughHighlightedMapRegions = Partial<{
+  [key in RoleId]: string[];
+}>;
 
 export interface WalkthroughOptions {
   stages: number;
@@ -10,7 +13,7 @@ export interface WalkthroughOptions {
   showDetailsWidget: boolean;
   showDivisibleInput?: boolean;
   showMaps: boolean;
-  highlightedMapRegions?: HighlightedMapRegions;
+  highlightedMapRegions?: WalkthroughHighlightedMapRegions;
   projectOverlay?: {
     roleId: 'buyer' | 'seller';
     project: Project;


### PR DESCRIPTION
As an alternative to https://github.com/curiousways/marketdesign/pull/101 we could actually use an SVG `<title>`, which most browsers will render as a tooltip, like this:

<img width="749" alt="image" src="https://user-images.githubusercontent.com/5636273/208918271-d3a4e4ce-f905-42d4-b144-7f91d81a69a5.png">

One potential downside is that it takes a few seconds to appear and there's no way to control that (all built in to the particular browser). A couple of options anyway, depending on whether they want the label to be there always, in which case we could go with the linked PR and accept that the positioning might feel a bit off, or are they ok with this tooltip approach and accepting that delay.