### PR TITLE
feat: add sandbox cheating mechanism

### DIFF
--- a/components/Checkbox/index.tsx
+++ b/components/Checkbox/index.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react';
+import { ChangeEvent, FC, ReactNode } from 'react';
 import { classNames } from '../../utils';
 
 type CheckboxProps = {
@@ -6,7 +6,7 @@ type CheckboxProps = {
   required?: boolean;
   disabled?: boolean;
   name: string;
-  onChange: () => void;
+  onChange: (evt: ChangeEvent<HTMLInputElement>) => void;
   children: ReactNode;
 };
 
@@ -18,7 +18,14 @@ export const Checkbox: FC<CheckboxProps> = ({
   onChange,
   children,
 }: CheckboxProps) => (
-  <label htmlFor={name} className={classNames('flex select-none', className)}>
+  // eslint-disable-next-line jsx-a11y/label-has-associated-control
+  <label
+    className={classNames(
+      'flex select-none',
+      !disabled ? 'cursor-pointer' : '',
+      className,
+    )}
+  >
     <span>
       <input
         required={required}
@@ -26,8 +33,11 @@ export const Checkbox: FC<CheckboxProps> = ({
         name={name}
         disabled={disabled}
         onChange={onChange}
+        className={!disabled ? 'cursor-pointer' : ''}
       />
     </span>
-    <span className="ml-2">{children}</span>
+    <span className={classNames('ml-2', disabled ? 'opacity-50' : '')}>
+      {children}
+    </span>
   </label>
 );

--- a/components/Checkbox/index.tsx
+++ b/components/Checkbox/index.tsx
@@ -1,0 +1,33 @@
+import { FC, ReactNode } from 'react';
+import { classNames } from '../../utils';
+
+type CheckboxProps = {
+  className?: string;
+  required?: boolean;
+  disabled?: boolean;
+  name: string;
+  onChange: () => void;
+  children: ReactNode;
+};
+
+export const Checkbox: FC<CheckboxProps> = ({
+  className,
+  required,
+  disabled,
+  name,
+  onChange,
+  children,
+}: CheckboxProps) => (
+  <label htmlFor={name} className={classNames('flex select-none', className)}>
+    <span>
+      <input
+        required={required}
+        type="checkbox"
+        name={name}
+        disabled={disabled}
+        onChange={onChange}
+      />
+    </span>
+    <span className="ml-2">{children}</span>
+  </label>
+);

--- a/components/Market/index.tsx
+++ b/components/Market/index.tsx
@@ -22,6 +22,7 @@ type MarketProps = {
   showMap?: boolean;
   highlightedMapRegions?: HighlightedMapRegions;
   investorRegions?: string[];
+  hideProducts?: boolean;
   onMapRegionClick?: (region: string) => void;
   link?: {
     href: string;
@@ -58,6 +59,7 @@ export const Market: FC<MarketProps> = ({
   loadingOverlayText,
   loadingBar,
   projectOverlay,
+  hideProducts,
 }: MarketProps) => (
   <div className="border-l border-green-dark pt-8 w-full relative flex justify-center">
     <div className="z-20">
@@ -82,6 +84,7 @@ export const Market: FC<MarketProps> = ({
         investorRegions={investorRegions}
         projectOverlay={projectOverlay}
         onMapRegionClick={onMapRegionClick}
+        hideProducts={hideProducts}
       />
     </div>
 

--- a/components/MarketParticipant/index.tsx
+++ b/components/MarketParticipant/index.tsx
@@ -44,6 +44,7 @@ type MarketParticipantProps = {
   isGroupedProject?: boolean;
   isDivisible?: boolean;
   totalCost?: number;
+  hideProducts?: boolean;
 };
 
 const calculatePayment = (
@@ -303,6 +304,7 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
   totalCost,
   isGroupedProject,
   isDivisible,
+  hideProducts,
 }: MarketParticipantProps) => {
   const isBuyer = projectRoleId === 'buyer';
 
@@ -427,29 +429,31 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
             />
 
             {/* Products */}
-            <div
-              className={classNames(
-                'flex',
-                showLoserStyles ? 'gap-x-4' : 'gap-x-10 flex-[20%]',
-              )}
-            >
-              <BiodiversityCount
-                type={isBuyer ? 'negative' : 'positive'}
-                boxStyle={isBuyer ? 'buyer' : 'seller'}
-                count={products.biodiversity}
-                adjustCount={showWinners}
-                accepted={accepted}
-                showLoserStyles={showLoserStyles}
-              />
-              <NutrientCount
-                type={isBuyer ? 'negative' : 'positive'}
-                boxStyle={isBuyer ? 'buyer' : 'seller'}
-                count={products.nutrients}
-                adjustCount={showWinners}
-                accepted={accepted}
-                showLoserStyles={showLoserStyles}
-              />
-            </div>
+            {(!hideProducts || isMyProject) && (
+              <div
+                className={classNames(
+                  'flex',
+                  showLoserStyles ? 'gap-x-4' : 'gap-x-10 flex-[20%]',
+                )}
+              >
+                <BiodiversityCount
+                  type={isBuyer ? 'negative' : 'positive'}
+                  boxStyle={isBuyer ? 'buyer' : 'seller'}
+                  count={products.biodiversity}
+                  adjustCount={showWinners}
+                  accepted={accepted}
+                  showLoserStyles={showLoserStyles}
+                />
+                <NutrientCount
+                  type={isBuyer ? 'negative' : 'positive'}
+                  boxStyle={isBuyer ? 'buyer' : 'seller'}
+                  count={products.nutrients}
+                  adjustCount={showWinners}
+                  accepted={accepted}
+                  showLoserStyles={showLoserStyles}
+                />
+              </div>
+            )}
 
             {!showLoserStyles && (
               <div className="flex gap-x-10 flex-[50%]">

--- a/components/MarketParticipantList/index.tsx
+++ b/components/MarketParticipantList/index.tsx
@@ -20,6 +20,7 @@ type MarketParticipantListProps = {
   showWinners?: boolean;
   showSurpluses?: boolean;
   isMarketSolved?: boolean;
+  hideProducts?: boolean;
 };
 
 /**
@@ -61,6 +62,7 @@ export const MarketParticipantList: FC<MarketParticipantListProps> = ({
   showWinners,
   showSurpluses,
   isMarketSolved,
+  hideProducts,
 }: MarketParticipantListProps) => {
   const { getProjectCost, getAcceptedProjectCost } = useProjectsContext();
   const sortedProjects = sortMyProjects(
@@ -131,6 +133,7 @@ export const MarketParticipantList: FC<MarketParticipantListProps> = ({
               showWinners={showWinners}
               showSurpluses={showSurpluses}
               isMarketSolved={isMarketSolved}
+              hideProducts={hideProducts}
             />
           </li>
         );

--- a/components/MarketScenario/index.tsx
+++ b/components/MarketScenario/index.tsx
@@ -27,6 +27,7 @@ type MarketScenarioProps = {
   showMap?: boolean;
   highlightedMapRegions?: HighlightedMapRegions;
   investorRegions?: string[];
+  hideProducts?: boolean;
   onMapRegionClick?: (region: string) => void;
   link?: {
     href: string;
@@ -55,6 +56,7 @@ export const MarketScenario: FC<MarketScenarioProps> = ({
   investorRegions,
   onMapRegionClick,
   projectOverlay,
+  hideProducts,
 }: MarketScenarioProps) => {
   const { getProjectCost } = useProjectsContext();
 
@@ -149,6 +151,7 @@ export const MarketScenario: FC<MarketScenarioProps> = ({
             showWinners={showWinners}
             showSurpluses={showSurpluses}
             isMarketSolved={isMarketSolved}
+            hideProducts={hideProducts}
           />
         </motion.div>
 

--- a/components/ProjectDetails/index.tsx
+++ b/components/ProjectDetails/index.tsx
@@ -13,6 +13,7 @@ import { MAP_INDICES } from '../../constants/map';
 import { Biodiversity } from '../Biodiversity';
 import { Nutrients } from '../Nutrients';
 import { Credit } from '../Credit';
+import { Checkbox } from '../Checkbox';
 
 type ProjectDetailsProps = {
   projects: Project[];
@@ -261,10 +262,12 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
 
         <div className="flex items-center">
           {showDivisibleInput ? (
-            // eslint-disable-next-line jsx-a11y/label-has-associated-control
-            <label
+            <Checkbox
+              required={isDivisibleInputEnabled}
+              name="is-divisible"
+              disabled={!isDivisibleInputEnabled}
+              onChange={onInputChange}
               className={classNames(
-                'flex select-none',
                 isDivisibleInputEnabled ? 'cursor-pointer' : '',
                 isFormEnabled &&
                   animatedInputName === 'is-divisible' &&
@@ -274,17 +277,8 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
                   : '',
               )}
             >
-              <span>
-                <input
-                  required={isDivisibleInputEnabled}
-                  type="checkbox"
-                  name="is-divisible"
-                  disabled={!isDivisibleInputEnabled}
-                  onChange={onInputChange}
-                />
-              </span>
-              <span className="ml-2">Divisible</span>
-            </label>
+              Divisible
+            </Checkbox>
           ) : (
             isInvestorScenario && (
               <span className="text-black opacity-30">Divisible</span>

--- a/components/ProjectDetails/index.tsx
+++ b/components/ProjectDetails/index.tsx
@@ -268,7 +268,6 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
               disabled={!isDivisibleInputEnabled}
               onChange={onInputChange}
               className={classNames(
-                isDivisibleInputEnabled ? 'cursor-pointer' : '',
                 isFormEnabled &&
                   animatedInputName === 'is-divisible' &&
                   isDivisibleInputEnabled &&


### PR DESCRIPTION
Adds a mechanism to let user's cheat within the market sandbox and reveal different levels of info before solving the market. What they're asking for here feels a little ambiguous but hopefully this is the sort of thing they were thinking of!

https://user-images.githubusercontent.com/5636273/208951541-dfa80fe6-855a-40e6-9f39-a5083914bd17.mov

