### PR TITLE
fix: only allow numbers in the cost input

### DIFF
--- a/components/CostInput/index.test.tsx
+++ b/components/CostInput/index.test.tsx
@@ -76,6 +76,27 @@ describe('CostInput', () => {
     expect(textInput).toBeValid();
   });
 
+  it('validates that the value entered is a number', async () => {
+    render(
+      <CostInput
+        name="my-input"
+        cost={42}
+        onInputChange={jest.fn()}
+        onSelectChange={jest.fn()}
+      />,
+    );
+
+    const textInput = screen.getByRole('textbox');
+
+    fireEvent.change(textInput, { target: { value: 'not a number' } });
+
+    expect(textInput).not.toBeValid();
+
+    fireEvent.change(textInput, { target: { value: '42' } });
+
+    expect(textInput).toBeValid();
+  });
+
   it('renders a select input if multiple costs are given', async () => {
     render(
       <CostInput

--- a/components/CostInput/index.tsx
+++ b/components/CostInput/index.tsx
@@ -34,7 +34,15 @@ export const CostInput: FC<CostInputProps> = ({
 
   const validateInput = useCallback(
     (element: HTMLInputElement) => {
+      if (element.value.length && !Number.isFinite(Number(element.value))) {
+        element.setCustomValidity('Please enter a number to proceed');
+
+        return;
+      }
+
       if (!bid) {
+        element.setCustomValidity('');
+
         return;
       }
 


### PR DESCRIPTION
> Needs to be some validation of bids.  Currently can submit text bids without any error being shown.  

<img width="559" alt="image" src="https://user-images.githubusercontent.com/5636273/208955589-2d14355a-ea5f-4414-a9b2-0744af51ad64.png">
