### PR TITLE
feat: modify investor product counts according to bid

### DIFF
--- a/components/BiodiversityCount/index.test.tsx
+++ b/components/BiodiversityCount/index.test.tsx
@@ -9,6 +9,7 @@ describe('BiodiversityCount', () => {
         type="positive"
         boxStyle="buyer"
         accepted
+        projectBid={1000}
       />,
     );
 
@@ -16,14 +17,27 @@ describe('BiodiversityCount', () => {
   });
 
   it('renders a count of zero if no count given', () => {
-    render(<BiodiversityCount type="positive" boxStyle="buyer" accepted />);
+    render(
+      <BiodiversityCount
+        type="positive"
+        boxStyle="buyer"
+        accepted
+        projectBid={1000}
+      />,
+    );
 
     expect(screen.getByTestId('product-count').textContent).toBe('0');
   });
 
   it('renders a count of zero', () => {
     render(
-      <BiodiversityCount count={0} type="positive" boxStyle="buyer" accepted />,
+      <BiodiversityCount
+        count={0}
+        type="positive"
+        boxStyle="buyer"
+        accepted
+        projectBid={1000}
+      />,
     );
 
     expect(screen.getByTestId('product-count').textContent).toBe('0');
@@ -37,6 +51,7 @@ describe('BiodiversityCount', () => {
         accepted={50}
         type="positive"
         boxStyle="buyer"
+        projectBid={1000}
       />,
     );
 
@@ -53,6 +68,7 @@ describe('BiodiversityCount', () => {
         accepted={50}
         type="positive"
         boxStyle="buyer"
+        projectBid={1000}
       />,
     );
 
@@ -68,10 +84,26 @@ describe('BiodiversityCount', () => {
         accepted={50}
         type="positive"
         boxStyle="buyer"
+        projectBid={1000}
       />,
     );
 
     expect(screen.getByTestId('losing-product-count').textContent).toBe('42');
     expect(screen.queryByTestId('product-count')).not.toBeInTheDocument();
+  });
+
+  it('modifies the count when there is a cost per credit', () => {
+    render(
+      <BiodiversityCount
+        type="positive"
+        boxStyle="buyer"
+        accepted
+        count={42}
+        projectBid={1000}
+        costPerCredit={100}
+      />,
+    );
+
+    expect(screen.getByTestId('product-count').textContent).toBe('4');
   });
 });

--- a/components/BiodiversityCount/index.tsx
+++ b/components/BiodiversityCount/index.tsx
@@ -9,6 +9,8 @@ type BiodiversityCountProps = {
   adjustCount?: boolean;
   accepted: number | boolean;
   showLoserStyles?: boolean;
+  projectBid: number;
+  costPerCredit?: number;
 };
 
 export const BiodiversityCount: FC<BiodiversityCountProps> = ({
@@ -18,8 +20,14 @@ export const BiodiversityCount: FC<BiodiversityCountProps> = ({
   accepted,
   adjustCount,
   showLoserStyles,
+  projectBid,
+  costPerCredit,
 }: BiodiversityCountProps) => {
   const hasCount = typeof count === 'number';
+  const maxCount =
+    hasCount && !!costPerCredit
+      ? Math.floor((costPerCredit * count) / projectBid)
+      : count;
 
   if (showLoserStyles) {
     return (
@@ -28,7 +36,7 @@ export const BiodiversityCount: FC<BiodiversityCountProps> = ({
           data-testid="losing-product-count"
           className="border border-black rounded-full bg-white w-[20px] h-[20px] flex justify-center items-center absolute -right-[8px] -top-[8px]"
         >
-          {count}
+          {maxCount}
         </div>
       </Biodiversity>
     );
@@ -37,7 +45,7 @@ export const BiodiversityCount: FC<BiodiversityCountProps> = ({
   return (
     <Biodiversity type={type} boxStyle={boxStyle} hidden={!hasCount}>
       <AdjustedProductCount
-        count={count ?? 0}
+        count={maxCount ?? 0}
         accepted={adjustCount ? accepted : true}
       />
     </Biodiversity>

--- a/components/MarketParticipant/index.tsx
+++ b/components/MarketParticipant/index.tsx
@@ -27,6 +27,7 @@ type MarketParticipantProps = {
   subtitle?: string;
   projectRoleId: 'buyer' | 'seller';
   projectCost: number;
+  projectBid: number;
   accepted?: boolean | number;
   discountOrBonus: number;
   products: Products;
@@ -44,6 +45,7 @@ type MarketParticipantProps = {
   isGroupedProject?: boolean;
   isDivisible?: boolean;
   totalCost?: number;
+  costPerCredit?: number;
 };
 
 const calculatePayment = (
@@ -286,6 +288,7 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
   subtitle,
   projectRoleId,
   projectCost,
+  projectBid,
   accepted = false,
   discountOrBonus,
   products,
@@ -303,6 +306,7 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
   totalCost,
   isGroupedProject,
   isDivisible,
+  costPerCredit,
 }: MarketParticipantProps) => {
   const isBuyer = projectRoleId === 'buyer';
 
@@ -440,6 +444,8 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
                 adjustCount={showWinners}
                 accepted={accepted}
                 showLoserStyles={showLoserStyles}
+                projectBid={projectBid}
+                costPerCredit={costPerCredit}
               />
               <NutrientCount
                 type={isBuyer ? 'negative' : 'positive'}
@@ -448,6 +454,8 @@ export const MarketParticipant: FC<MarketParticipantProps> = ({
                 adjustCount={showWinners}
                 accepted={accepted}
                 showLoserStyles={showLoserStyles}
+                projectBid={projectBid}
+                costPerCredit={costPerCredit}
               />
             </div>
 

--- a/components/MarketParticipantList/index.tsx
+++ b/components/MarketParticipantList/index.tsx
@@ -87,6 +87,7 @@ export const MarketParticipantList: FC<MarketParticipantListProps> = ({
           groupedProjects.indexOf(project) === groupedProjects.length - 1;
 
         const projectCost = getProjectCost(project, true);
+        const projectBid = getProjectCost(project);
 
         const isDivisible = !!project.costPerCredit;
         const allGroupedProjectsWon =
@@ -123,6 +124,7 @@ export const MarketParticipantList: FC<MarketParticipantListProps> = ({
                 isGroupedProject && !isFirstGroupedProject
               }
               projectCost={projectCost}
+              projectBid={projectBid}
               totalCost={totalCost}
               discountOrBonus={project.discountOrBonus}
               products={project.products}
@@ -131,6 +133,7 @@ export const MarketParticipantList: FC<MarketParticipantListProps> = ({
               showWinners={showWinners}
               showSurpluses={showSurpluses}
               isMarketSolved={isMarketSolved}
+              costPerCredit={project.costPerCredit}
             />
           </li>
         );

--- a/components/MarketSandbox/index.tsx
+++ b/components/MarketSandbox/index.tsx
@@ -324,6 +324,22 @@ const getHighlightedMapRegions = (
   return regions;
 };
 
+const getAdjustedProductCount = (
+  project: Project,
+  projectCost: number,
+  productCount: number,
+) => {
+  const positiveProductCount = Math.abs(productCount);
+
+  if (!project.costPerCredit || !positiveProductCount) {
+    return productCount;
+  }
+
+  return Math.floor(
+    (project.costPerCredit * positiveProductCount) / projectCost,
+  );
+};
+
 const getInvestorRegions = (traders: DemoTrader[]): string[] => {
   const regions: string[] = [];
 
@@ -393,6 +409,18 @@ export const MarketSandbox: NextPage<MarketSandboxProps> = ({
       );
 
       bid.v = getProjectCost(project);
+
+      bid.q.biodiversity = getAdjustedProductCount(
+        project,
+        bid.v,
+        bid.q.biodiversity,
+      );
+
+      bid.q.nutrients = getAdjustedProductCount(
+        project,
+        bid.v,
+        bid.q.nutrients,
+      );
 
       if (roleId === 'seller') {
         bid.v *= -1;

--- a/components/MarketSandbox/index.tsx
+++ b/components/MarketSandbox/index.tsx
@@ -396,6 +396,16 @@ export const MarketSandbox: NextPage<MarketSandboxProps> = ({
     return newMarketState;
   }, []);
 
+  const showDivisibleInput = myProjects.some((project) => {
+    if (project.costPerCredit) {
+      return false;
+    }
+
+    const bid = findBidForProject(playableTraders, demoState.bidders, project);
+
+    return !!bid.divisibility;
+  });
+
   const onSolveMarketClick = useCallback(async () => {
     if (!demoState) {
       throw new Error(
@@ -432,7 +442,9 @@ export const MarketSandbox: NextPage<MarketSandboxProps> = ({
         bid.v *= -1;
       }
 
-      bid.divisibility = isProjectDivisible(project) ? 1 : 0;
+      if (showDivisibleInput) {
+        bid.divisibility = isProjectDivisible(project) ? 1 : 0;
+      }
     });
 
     const res = await fetch(API_URL, {
@@ -467,6 +479,7 @@ export const MarketSandbox: NextPage<MarketSandboxProps> = ({
     playableTraders,
     getNewMarketState,
     isProjectDivisible,
+    showDivisibleInput,
   ]);
 
   const onFormSubmit = useCallback(() => {
@@ -488,16 +501,6 @@ export const MarketSandbox: NextPage<MarketSandboxProps> = ({
     },
     [playableTraders],
   );
-
-  const showDivisibleInput = myProjects.some((project) => {
-    if (project.costPerCredit) {
-      return false;
-    }
-
-    const bid = findBidForProject(playableTraders, demoState.bidders, project);
-
-    return !!bid.divisibility;
-  });
 
   const [pathname] = router.asPath.split('?');
 

--- a/components/MarketScenario/index.tsx
+++ b/components/MarketScenario/index.tsx
@@ -185,6 +185,7 @@ export const MarketScenario: FC<MarketScenarioProps> = ({
               title={projectOverlay.project.title}
               subtitle={projectOverlay.project.subtitle}
               projectCost={getProjectCost(projectOverlay.project)}
+              projectBid={getProjectCost(projectOverlay.project)}
               discountOrBonus={projectOverlay.project.discountOrBonus}
               products={projectOverlay.project.products}
             />

--- a/components/NutrientCount/index.test.tsx
+++ b/components/NutrientCount/index.test.tsx
@@ -4,21 +4,40 @@ import { NutrientCount } from './index';
 describe('NutrientCount', () => {
   it('renders the count', () => {
     render(
-      <NutrientCount count={42} type="positive" boxStyle="buyer" accepted />,
+      <NutrientCount
+        count={42}
+        type="positive"
+        boxStyle="buyer"
+        accepted
+        projectBid={1000}
+      />,
     );
 
     expect(screen.getByTestId('product-count').textContent).toBe('42');
   });
 
   it('renders a count of zero if no count given', () => {
-    render(<NutrientCount type="positive" boxStyle="buyer" accepted />);
+    render(
+      <NutrientCount
+        type="positive"
+        boxStyle="buyer"
+        accepted
+        projectBid={1000}
+      />,
+    );
 
     expect(screen.getByTestId('product-count').textContent).toBe('0');
   });
 
   it('renders a count of zero', () => {
     render(
-      <NutrientCount count={0} type="positive" boxStyle="buyer" accepted />,
+      <NutrientCount
+        count={0}
+        type="positive"
+        boxStyle="buyer"
+        accepted
+        projectBid={1000}
+      />,
     );
 
     expect(screen.getByTestId('product-count').textContent).toBe('0');
@@ -30,6 +49,7 @@ describe('NutrientCount', () => {
         adjustCount
         count={42}
         accepted={50}
+        projectBid={1000}
         type="positive"
         boxStyle="buyer"
       />,
@@ -46,6 +66,7 @@ describe('NutrientCount', () => {
       <NutrientCount
         count={42}
         accepted={50}
+        projectBid={1000}
         boxStyle="buyer"
         type="positive"
       />,
@@ -61,6 +82,7 @@ describe('NutrientCount', () => {
         showLoserStyles
         count={42}
         accepted={50}
+        projectBid={1000}
         type="positive"
         boxStyle="buyer"
       />,
@@ -68,5 +90,20 @@ describe('NutrientCount', () => {
 
     expect(screen.getByTestId('losing-product-count').textContent).toBe('42');
     expect(screen.queryByTestId('product-count')).not.toBeInTheDocument();
+  });
+
+  it('modifies the count when there is a cost per credit', () => {
+    render(
+      <NutrientCount
+        type="positive"
+        boxStyle="buyer"
+        accepted
+        count={42}
+        projectBid={1000}
+        costPerCredit={100}
+      />,
+    );
+
+    expect(screen.getByTestId('product-count').textContent).toBe('4');
   });
 });

--- a/components/NutrientCount/index.tsx
+++ b/components/NutrientCount/index.tsx
@@ -9,6 +9,8 @@ type NutrientCountProps = {
   adjustCount?: boolean;
   accepted: number | boolean;
   showLoserStyles?: boolean;
+  projectBid: number;
+  costPerCredit?: number;
 };
 
 export const NutrientCount: FC<NutrientCountProps> = ({
@@ -18,8 +20,14 @@ export const NutrientCount: FC<NutrientCountProps> = ({
   accepted,
   adjustCount,
   showLoserStyles,
+  projectBid,
+  costPerCredit,
 }: NutrientCountProps) => {
   const hasCount = typeof count === 'number';
+  const maxCount =
+    hasCount && !!costPerCredit
+      ? Math.floor((costPerCredit * count) / projectBid)
+      : count;
 
   if (showLoserStyles) {
     return (
@@ -28,7 +36,7 @@ export const NutrientCount: FC<NutrientCountProps> = ({
           data-testid="losing-product-count"
           className="border border-black rounded-full bg-white w-[20px] h-[20px] flex justify-center items-center absolute -right-[8px] -top-[8px]"
         >
-          {count}
+          {maxCount}
         </div>
       </Nutrients>
     );
@@ -37,7 +45,7 @@ export const NutrientCount: FC<NutrientCountProps> = ({
   return (
     <Nutrients type={type} boxStyle={boxStyle} hidden={!hasCount}>
       <AdjustedProductCount
-        count={count ?? 0}
+        count={maxCount ?? 0}
         accepted={adjustCount ? accepted : true}
       />
     </Nutrients>

--- a/components/ProductCount/index.tsx
+++ b/components/ProductCount/index.tsx
@@ -13,7 +13,7 @@ export const ProductCount: FC<ProductCountProps> = ({
   <div
     data-testid="product-count"
     className={classNames(
-      'absolute right-0 border-black rounded-full bg-white w-[29px] h-[29px] flex justify-center items-center',
+      'absolute right-0 border-black rounded-full bg-white min-w-[29px] min-h-[29px] leading-[.5rem] p-[.5rem] flex justify-center items-center',
       className,
     )}
   >

--- a/types/demo.ts
+++ b/types/demo.ts
@@ -1,9 +1,11 @@
+export type DemoProducts = {
+  biodiversity: number;
+  nutrients: number;
+};
+
 export type DemoBid = {
   v: number;
-  q: {
-    biodiversity: number;
-    nutrients: number;
-  };
+  q: DemoProducts;
   divisibility: number;
   label?: string;
   xor_group?: string;


### PR DESCRIPTION
> Once an investor has made their bid, a little bit of logic needs doing to formulate the credit quantities on their bid strip. As for all buyers we need to fix the maximum number of credits of each type that the investor is looking to buy ... though because an investor's bid is divisible they could buy less than this number but no more. It's this maximum number that needs to be presented on the bid strip. To work out this maximum credit demand we first note that the investor has a budget either for that type of credit or for all credits; call that £B. Now if they bid £x for a credit type, they may be successful at that price so the maximum number of credits is fixed at £B/£x rounded down to the nearest integer. That needs to be done for all credit types for which the investor is expressing a demand.

> The maximum credit quantity calculated after the investor places their bids needs to be updated in the JSON string sent to the solution API.

I think the changes in this PR is what they're after but to be honest I find this investor bidding thing quite confusing. Partly as the API is a bit of a black box to me, so we submit some data, get some result back and present it, but whether or not that result is what we expect I have no idea, which makes this quite a hard one to test!