### PR TITLE
fix: update the condition under which the "divisible" text is shown

### DIFF
--- a/components/MarketOutcome/index.test.tsx
+++ b/components/MarketOutcome/index.test.tsx
@@ -13,6 +13,8 @@ const wrapper = ({ children }: WrapperProps) => (
       getAcceptedProjectCost: jest.fn(({ cost }) =>
         Array.isArray(cost) ? cost[0] : cost,
       ),
+      setIsProjectDivisible: jest.fn(),
+      isProjectDivisible: () => false,
     }}
   >
     {children}

--- a/components/MarketParticipantList/index.test.tsx
+++ b/components/MarketParticipantList/index.test.tsx
@@ -22,6 +22,8 @@ const wrapper = ({ children }: WrapperProps) => (
       getProjectCost: jest.fn(({ cost }) =>
         Array.isArray(cost) ? cost[0] : cost,
       ),
+      setIsProjectDivisible: jest.fn(),
+      isProjectDivisible: () => false,
     }}
   >
     {children}

--- a/components/MarketParticipantList/index.tsx
+++ b/components/MarketParticipantList/index.tsx
@@ -62,7 +62,9 @@ export const MarketParticipantList: FC<MarketParticipantListProps> = ({
   showSurpluses,
   isMarketSolved,
 }: MarketParticipantListProps) => {
-  const { getProjectCost, getAcceptedProjectCost } = useProjectsContext();
+  const { getProjectCost, getAcceptedProjectCost, isProjectDivisible } =
+    useProjectsContext();
+
   const sortedProjects = sortMyProjects(
     myProjects,
     buyerProjects,
@@ -88,7 +90,9 @@ export const MarketParticipantList: FC<MarketParticipantListProps> = ({
 
         const projectCost = getProjectCost(project, true);
 
-        const isDivisible = !!project.costPerCredit;
+        const isDivisible =
+          !!project.costPerCredit || isProjectDivisible(project);
+
         const allGroupedProjectsWon =
           groupedProjects.length > 1 &&
           groupedProjects.every((groupedProject) =>

--- a/components/MarketSandbox/index.tsx
+++ b/components/MarketSandbox/index.tsx
@@ -348,7 +348,7 @@ export const MarketSandbox: NextPage<MarketSandboxProps> = ({
   const [demoState, setDemoState] = useState<DemoState>(data.states[0]);
   const [selectedMapRegion, setSelectedMapRegion] = useState<string>();
   const [playableTrader, setPlayableTrader] = useState<DemoTrader>();
-  const { getProjectCost } = useProjectsContext();
+  const { getProjectCost, isProjectDivisible } = useProjectsContext();
   const { playable_traders: playableTraders } = data;
 
   const myProjects = getProjectsForTrader(
@@ -397,6 +397,8 @@ export const MarketSandbox: NextPage<MarketSandboxProps> = ({
       if (roleId === 'seller') {
         bid.v *= -1;
       }
+
+      bid.divisibility = isProjectDivisible(project) ? 1 : 0;
     });
 
     const res = await fetch(API_URL, {
@@ -430,6 +432,7 @@ export const MarketSandbox: NextPage<MarketSandboxProps> = ({
     getProjectCost,
     playableTraders,
     getNewMarketState,
+    isProjectDivisible,
   ]);
 
   const onFormSubmit = useCallback(() => {
@@ -452,6 +455,16 @@ export const MarketSandbox: NextPage<MarketSandboxProps> = ({
     [playableTraders],
   );
 
+  const showDivisibleInput = myProjects.some((project) => {
+    if (project.costPerCredit) {
+      return false;
+    }
+
+    const bid = findBidForProject(playableTraders, demoState.bidders, project);
+
+    return !!bid.divisibility;
+  });
+
   return (
     <MainContainer>
       <SideBar
@@ -467,6 +480,8 @@ export const MarketSandbox: NextPage<MarketSandboxProps> = ({
         onFormRevise={onFormRevise}
         roleId={roleId}
         showSolveMarketBtn={marketState === MarketState.solvable}
+        isDivisibleInputEnabled={showDivisibleInput}
+        showDivisibleInput={showDivisibleInput}
       />
       <Market
         showMap

--- a/components/ProjectDetails/index.test.tsx
+++ b/components/ProjectDetails/index.test.tsx
@@ -18,6 +18,7 @@ const createProject = (overrides?: Partial<Project>) => ({
 type WrapperProps = { children: ReactNode };
 
 const setProjectCost = jest.fn();
+const setIsProjectDivisible = jest.fn();
 
 const wrapper = ({ children }: WrapperProps) => (
   <ProjectsContext.Provider
@@ -25,6 +26,8 @@ const wrapper = ({ children }: WrapperProps) => (
       setProjectCost,
       getProjectCost: jest.fn(),
       getAcceptedProjectCost: jest.fn(),
+      setIsProjectDivisible,
+      isProjectDivisible: () => false,
     }}
   >
     {children}
@@ -245,6 +248,49 @@ describe('ProjectDetails', () => {
     fireEvent.submit(screen.getByText('Submit'));
 
     expect(onFormSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates the project divisibility when the divisibility input is checked', async () => {
+    const project = createProject();
+
+    render(
+      <ProjectDetails
+        isFormEnabled
+        showDivisibleInput
+        isDivisibleInputEnabled
+        projects={[project]}
+        onFormSubmit={jest.fn()}
+        roleId="buyer"
+      />,
+      { wrapper },
+    );
+
+    fireEvent.click(screen.getByText('Divisible'));
+    fireEvent.submit(screen.getByText('Submit'));
+
+    expect(setIsProjectDivisible).toHaveBeenCalledTimes(1);
+    expect(setIsProjectDivisible).toHaveBeenCalledWith(project, true);
+  });
+
+  it('updates the project divisibility when the divisibility input is not checked', async () => {
+    const project = createProject();
+
+    render(
+      <ProjectDetails
+        isFormEnabled
+        showDivisibleInput
+        isDivisibleInputEnabled
+        projects={[project]}
+        onFormSubmit={jest.fn()}
+        roleId="buyer"
+      />,
+      { wrapper },
+    );
+
+    fireEvent.submit(screen.getByText('Submit'));
+
+    expect(setIsProjectDivisible).toHaveBeenCalledTimes(1);
+    expect(setIsProjectDivisible).toHaveBeenCalledWith(project, false);
   });
 
   it('revises the form if enabled', () => {

--- a/components/ProjectDetails/index.tsx
+++ b/components/ProjectDetails/index.tsx
@@ -79,8 +79,11 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
   roleId,
   animateNextSteps,
 }: ProjectDetailsProps) => {
-  const { getProjectCost, setProjectCost } = useProjectsContext();
+  const { getProjectCost, setProjectCost, setIsProjectDivisible } =
+    useProjectsContext();
+
   const { sharedCost } = projects.find((project) => !!project.sharedCost) ?? {};
+  const divisibleInputRef = useRef<HTMLInputElement>(null);
 
   const priceInputNames = projects.map((_, index) => `project-${index}-price`);
 
@@ -103,6 +106,11 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
 
   const onSubmit = (event: FormEvent) => {
     event.preventDefault();
+
+    projects.forEach((project) => {
+      setIsProjectDivisible(project, !!divisibleInputRef.current?.checked);
+    });
+
     onFormSubmit();
   };
 
@@ -163,7 +171,7 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
                   project.isInactive ? 'opacity-30' : '',
                 )}
               >
-                {!!project.subtitle && projects.length > 1 && (
+                {!!project.subtitle && (
                   <span className="flex justify-end text-sm underline">
                     {project.subtitle}
                   </span>
@@ -276,6 +284,7 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
             >
               <span>
                 <input
+                  ref={divisibleInputRef}
                   required={isDivisibleInputEnabled}
                   type="checkbox"
                   name="is-divisible"

--- a/components/ProjectDetails/index.tsx
+++ b/components/ProjectDetails/index.tsx
@@ -21,6 +21,7 @@ type ProjectDetailsProps = {
   isFormSubmitHidden?: boolean;
   hasFixedBids?: boolean;
   isDivisibleInputEnabled?: boolean;
+  isDivisibleInputRequired?: boolean;
   showDivisibleInput?: boolean;
   onFormSubmit: () => void;
   onFormRevise?: () => void;
@@ -73,6 +74,7 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
   isFormSubmitHidden,
   hasFixedBids,
   isDivisibleInputEnabled,
+  isDivisibleInputRequired,
   showDivisibleInput,
   onFormSubmit,
   onFormRevise,
@@ -285,7 +287,7 @@ export const ProjectDetails: FC<ProjectDetailsProps> = ({
               <span>
                 <input
                   ref={divisibleInputRef}
-                  required={isDivisibleInputEnabled}
+                  required={isDivisibleInputRequired}
                   type="checkbox"
                   name="is-divisible"
                   disabled={!isDivisibleInputEnabled}

--- a/components/Sidebar/index.tsx
+++ b/components/Sidebar/index.tsx
@@ -26,6 +26,7 @@ type SidebarProps = {
   animateNextSteps?: boolean;
   hasFixedBids?: boolean;
   isDivisibleInputEnabled?: boolean;
+  isDivisibleInputRequired?: boolean;
   showDivisibleInput?: boolean;
   onFormSubmit: () => void;
   onFormRevise?: () => void;
@@ -50,6 +51,7 @@ export const SideBar: FC<SidebarProps> = ({
   animateNextSteps,
   hasFixedBids,
   isDivisibleInputEnabled,
+  isDivisibleInputRequired,
   showDivisibleInput,
   onFormSubmit,
   onFormRevise,
@@ -69,6 +71,7 @@ export const SideBar: FC<SidebarProps> = ({
             isFormSubmitHidden={isFormSubmitHidden}
             hasFixedBids={hasFixedBids}
             isDivisibleInputEnabled={isDivisibleInputEnabled}
+            isDivisibleInputRequired={isDivisibleInputRequired}
             showDivisibleInput={showDivisibleInput}
             onFormSubmit={onFormSubmit}
             onFormRevise={onFormRevise}

--- a/components/Walkthrough/index.tsx
+++ b/components/Walkthrough/index.tsx
@@ -181,6 +181,7 @@ export const Walkthrough: FC = () => {
         isFormEnabled={isFormEnabled}
         isFormSubmitHidden={marketState === MarketState.solved}
         isDivisibleInputEnabled={isFormEnabled && allowDivision}
+        isDivisibleInputRequired={isFormEnabled && allowDivision}
         showDivisibleInput={showDivisibleInput}
         onFormSubmit={onFormSubmit}
         roleId={roleId}

--- a/context/ProjectsContext.tsx
+++ b/context/ProjectsContext.tsx
@@ -14,11 +14,14 @@ type ProjectsContextType = {
   getProjectCost: (project: Project, sumCredits?: boolean) => number;
   setProjectCost: (project: Project, cost: number) => void;
   getAcceptedProjectCost: (project: Project) => number;
+  isProjectDivisible: (project: Project) => boolean;
+  setIsProjectDivisible: (project: Project, divisible: boolean) => void;
 };
 
 type ProjectsState = {
   project: Project;
   cost?: number;
+  divisible?: boolean;
 }[];
 
 type ProjectsUpdateCostAction = {
@@ -26,7 +29,14 @@ type ProjectsUpdateCostAction = {
   value: { project: Project; cost: number };
 };
 
-type ProjectsAction = ProjectsUpdateCostAction;
+type ProjectsUpdateDivisibilityAction = {
+  type: 'UPDATE_DIVISIBILITY';
+  value: { project: Project; divisible: boolean };
+};
+
+type ProjectsAction =
+  | ProjectsUpdateCostAction
+  | ProjectsUpdateDivisibilityAction;
 
 const findEntry = (state: ProjectsState, project: Project) =>
   state.find((item) => isProjectEqual(item.project, project));
@@ -49,6 +59,19 @@ const reducer = (
       return [...state, { project, cost }];
     }
 
+    case 'UPDATE_DIVISIBILITY': {
+      const { project, divisible } = action.value;
+      const entry = findEntry(state, action.value.project);
+
+      if (entry) {
+        entry.divisible = divisible;
+
+        return state;
+      }
+
+      return [...state, { project, divisible }];
+    }
+
     default:
       throw new Error('Unknown action');
   }
@@ -68,6 +91,13 @@ export const ProjectsProvider: FunctionComponent<ProjectsProviderProps> = ({
   const setProjectCost = useCallback((project: Project, cost: number) => {
     dispatch({ type: 'UPDATE_COST', value: { project, cost } });
   }, []);
+
+  const setIsProjectDivisible = useCallback(
+    (project: Project, divisible: boolean) => {
+      dispatch({ type: 'UPDATE_DIVISIBILITY', value: { project, divisible } });
+    },
+    [],
+  );
 
   const getProjectCost = useCallback(
     (project: Project, sumCredits?: boolean): number => {
@@ -92,6 +122,15 @@ export const ProjectsProvider: FunctionComponent<ProjectsProviderProps> = ({
     [state],
   );
 
+  const isProjectDivisible = useCallback(
+    (project: Project): boolean => {
+      const { divisible = false } = findEntry(state, project) ?? {};
+
+      return divisible;
+    },
+    [state],
+  );
+
   const getAcceptedProjectCost = useCallback(
     (project: Project): number => {
       const cost = getProjectCost(project);
@@ -107,8 +146,16 @@ export const ProjectsProvider: FunctionComponent<ProjectsProviderProps> = ({
       getProjectCost,
       setProjectCost,
       getAcceptedProjectCost,
+      isProjectDivisible,
+      setIsProjectDivisible,
     }),
-    [getProjectCost, setProjectCost, getAcceptedProjectCost],
+    [
+      getProjectCost,
+      setProjectCost,
+      getAcceptedProjectCost,
+      isProjectDivisible,
+      setIsProjectDivisible,
+    ],
   );
 
   return (

--- a/data/demo/Market-WlkThruB4.json
+++ b/data/demo/Market-WlkThruB4.json
@@ -74,7 +74,7 @@
                 "biodiversity": -3,
                 "nutrients": -6
               },
-              "divisibility": 0
+              "divisibility": 1
             }
           ]
         },

--- a/data/walkthroughs/scenarios/buyers/4.1/index.ts
+++ b/data/walkthroughs/scenarios/buyers/4.1/index.ts
@@ -11,7 +11,6 @@ export const getBuyerScenario4_1: GetWalkthroughScenario = (stage: number) => ({
   myProjects: [
     {
       title: 'My Project',
-      subtitle: 'Divisible',
       cost: 180000,
       // The number below is so specific because we wanted specifically 120,000
       // to be accepted (67% of 180,000 is actually 120,600).


### PR DESCRIPTION
Covers:

> We made a mistake in the JSON we sent through for walkthruB4. Buyer 1 should have had the "divisibility" = 1. That should result in the my project box having the tick box option for divisible. And then should result in a playout that allows a portion of the bid to be accepted. Since we got that JSON wrong, not certain whether that logic is implemented yet. Sorry!

and 

> market-sandbox/market-wlk-thru-s4-1: The label “wood” is shown on the bid strip but not in the my
project box.  Would expect it to appear in the my project box too for consistency like in /market-sandbox/market-wlk-thru-s4-3


https://user-images.githubusercontent.com/5636273/209005467-c4aa8668-44c8-4e2c-901b-791ff51470f2.mov
